### PR TITLE
feat: add dispose() teardown method with isDisposed guard

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,4 @@
+require:
+  - ./test/setup-dom.cjs
+spec: test/*.js
+reporter: spec

--- a/lib/render.js
+++ b/lib/render.js
@@ -116,7 +116,8 @@ class Renderer {
 
         // Raycast for clicks
         this._rcastlist = [];
-        this._r.domElement.addEventListener('pointerdown', this._raycastClick.bind(this));
+        this._boundRaycastClick = this._raycastClick.bind(this);
+        this._r.domElement.addEventListener('pointerdown', this._boundRaycastClick);
 
         // Groups
         this._groups = {
@@ -162,7 +163,7 @@ class Renderer {
     }
 
     _animate() {
-        requestAnimationFrame(this._animate.bind(this));
+        this._animFrameId = requestAnimationFrame(this._animate.bind(this));
         this._render();
     }
 
@@ -333,6 +334,48 @@ class Renderer {
      */
     removeSelBoxListener(sbl) {
         _.pull(this._sboxlist, sbl);
+    }
+
+    /**
+     * Tear down the renderer, cancelling the animation loop, removing all canvas
+     * event listeners (orbit controls, raycaster, selection box), disconnecting any
+     * ResizeObserver, and releasing the WebGL context.  After this call the instance
+     * must not be used again.
+     */
+    dispose() {
+        // 1. Stop the animation loop
+        if (this._animFrameId != null) {
+            cancelAnimationFrame(this._animFrameId);
+            this._animFrameId = null;
+        }
+
+        // 2. Remove the raycaster's own pointerdown listener
+        this._r.domElement.removeEventListener('pointerdown', this._boundRaycastClick);
+        this._rcastlist = [];
+        this._sboxlist = [];
+
+        // 3. Dispose OrbitControls (removes its own listeners from the canvas)
+        if (this._oc) {
+            this._oc.dispose();
+            this._oc = null;
+        }
+
+        // 4. Dispose the selection box helper (removes its listeners and overlay)
+        if (this._sboxhelp) {
+            this._sboxhelp.dispose();
+            this._sboxhelp = null;
+        }
+
+        // 5. Stop watching for container resize
+        if (this._resizeObs) {
+            this._resizeObs.disconnect();
+            this._resizeObs = null;
+        }
+
+        // 6. Release the WebGL context and GPU resources
+        this._r.dispose();
+        this._r.domElement.remove();
+        this._r = null;
     }
 
     /**

--- a/lib/selbox.js
+++ b/lib/selbox.js
@@ -256,6 +256,10 @@ var SelectionHelper = (function() {
         this.isDown = false;
         this.selectOverCallback = null;
 
+        // AbortController lets us remove all listeners in one call via dispose()
+        this._ac = new AbortController();
+        const signal = this._ac.signal;
+
         this.domElement.addEventListener('pointerdown', function(event) {
 
             if (event.shiftKey) {
@@ -263,7 +267,7 @@ var SelectionHelper = (function() {
                 this.onSelectStart(event);
             }
 
-        }.bind(this), false);
+        }.bind(this), { signal });
 
         this.domElement.addEventListener('pointermove', function(event) {
 
@@ -273,7 +277,7 @@ var SelectionHelper = (function() {
 
             }
 
-        }.bind(this), false);
+        }.bind(this), { signal });
 
         this.domElement.addEventListener('pointerup', function(event) {
 
@@ -282,7 +286,7 @@ var SelectionHelper = (function() {
                 this.onSelectOver(event);
             }
 
-        }.bind(this), false);
+        }.bind(this), { signal });
 
         this.domElement.addEventListener('keyup', function(event) {
 
@@ -291,9 +295,19 @@ var SelectionHelper = (function() {
                 this.onSelectOver(event);
             }
 
-        }.bind(this), false);
+        }.bind(this), { signal });
 
     }
+
+    SelectionHelper.prototype.dispose = function() {
+        // Remove all canvas event listeners registered by this helper
+        this._ac.abort();
+        // Remove the overlay element from the DOM
+        if (this.element) {
+            this.element.remove();
+            this.element = null;
+        }
+    };
 
     SelectionHelper.prototype.onSelectStart = function(event) {
 

--- a/lib/visualizer.js
+++ b/lib/visualizer.js
@@ -85,6 +85,19 @@ class CrystVis {
         // Vanilla (no get/set needed)
         this.cifsymtol = 1e-2; // Parameter controlling the tolerance to symmetry when loading CIF files
 
+        // Disposal state
+        this._isDisposed = false;
+
+    }
+
+    /**
+     * Whether this instance has been disposed.
+     * Once true, most methods will throw rather than silently fail.
+     * @readonly
+     * @type {boolean}
+     */
+    get isDisposed() {
+        return this._isDisposed;
     }
 
     /**
@@ -315,6 +328,38 @@ class CrystVis {
      *                           which the center of the camera should be rendered with
      *                           respect to the center of the canvas
      */
+    /**
+     * Release all resources held by this instance: cancels the animation loop,
+     * removes all canvas event listeners, disposes OrbitControls and the
+     * THREE.WebGLRenderer, and nulls internal references.  After calling this
+     * method the instance must not be used again.
+     */
+    dispose() {
+        if (this._isDisposed) {
+            return;
+        }
+        this._isDisposed = true;
+
+        // Tear down the renderer (animation loop, orbit controls, WebGL context)
+        if (this._renderer) {
+            this._renderer.dispose();
+            this._renderer = null;
+        }
+
+        // Drop model and view references
+        this._current_model = null;
+        this._current_mname = null;
+        this._displayed = null;
+        this._selected = null;
+        this._models = {};
+
+        // Drop event callbacks
+        this._atom_click_events = {};
+        this._atom_click_defaults = {};
+        this._atom_box_event = null;
+        this._notifications = [];
+    }
+
     centerCamera(center = [0, 0, 0], shift = [0, 0]) {
         const renderer = this._renderer;
 
@@ -339,6 +384,9 @@ class CrystVis {
      * @return {Object}             Names of the models we tried to load, and values of true/false for successful loading or not
      */
     loadModels(contents, format = 'cif', prefix = null, parameters = {}) {
+        if (this._isDisposed) {
+            throw new Error('CrystVis: cannot call loadModels() on a disposed instance');
+        }
         // clear existing notifications
         this.clearNotifications();
 
@@ -392,6 +440,9 @@ class CrystVis {
      * @param  {Object} parameters Loading parameters as in .loadModels()
      */
     reloadModel(name, parameters = {}) {
+        if (this._isDisposed) {
+            throw new Error('CrystVis: cannot call reloadModel() on a disposed instance');
+        }
         // clear existing notifications from scene
         this.clearNotifications();
 
@@ -422,6 +473,9 @@ class CrystVis {
      *                          clear the renderer window.
      */
     displayModel(name = null) {
+        if (this._isDisposed) {
+            throw new Error('CrystVis: cannot call displayModel() on a disposed instance');
+        }
 
         if (this._current_model) {
             // clear notifications from previous model

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,12 +33,68 @@
         "glob": "^11.1.0",
         "jpeg-js": "^0.4.4",
         "jsdoc": "^4.0.5",
+        "jsdom": "^27.0.1",
         "minimist": "^1.2.8",
         "mocha": "^11.7.5",
         "msdf-bmfont-xml": "^2.8.0",
         "npm-watch": "^0.13.0",
         "serve": "^14.2.5"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -374,6 +430,138 @@
       "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
+      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1788,6 +1976,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2000,6 +2198,16 @@
       "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2704,6 +2912,70 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/datauri": {
@@ -3822,6 +4094,19 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-minifier-terser": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
@@ -3854,6 +4139,34 @@
         "node": ">=14"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3862,6 +4175,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -4154,6 +4480,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4349,6 +4682,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4694,6 +5067,13 @@
       "integrity": "sha512-bG6qXujJ1QgttZVIH4WDanhoJtvbud/xP/XPyf6A69C9RdA61BM4TomFALCq2nrTa+tARRIBB4LuIFsnUQU2wA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -5587,6 +5967,32 @@
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -6118,6 +6524,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6163,6 +6576,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -6170,6 +6590,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/seed-random": {
@@ -6412,6 +6845,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -6592,6 +7035,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
@@ -6678,6 +7128,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6717,6 +7187,32 @@
       "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-repeated": {
@@ -7120,6 +7616,67 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/when-exit": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
@@ -7354,6 +7911,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
@@ -7377,6 +7956,16 @@
         "is-function": "^1.0.1",
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xml-parse-from-string": {
@@ -7406,6 +7995,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "glob": "^11.1.0",
     "jpeg-js": "^0.4.4",
     "jsdoc": "^4.0.5",
+    "jsdom": "^27.0.1",
     "minimist": "^1.2.8",
     "mocha": "^11.7.5",
     "msdf-bmfont-xml": "^2.8.0",

--- a/test/setup-dom.cjs
+++ b/test/setup-dom.cjs
@@ -1,0 +1,147 @@
+/**
+ * test/setup-dom.cjs
+ *
+ * Mocha --require hook (CommonJS) that installs a minimal jsdom window as
+ * global so that DOM-dependent ES modules (THREE.js texture loader, jQuery,
+ * etc.) can be imported in the Node.js test environment without crashing.
+ */
+
+'use strict';
+
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="crystvis"></div></body></html>', {
+    pretendToBeVisual: true,
+    resources: 'usable',
+});
+
+// Helper: set a global, falling back to Object.defineProperty for read-only
+// properties (e.g. navigator in Node.js 23+).
+function setGlobal(name, value) {
+    try {
+        global[name] = value;
+    } catch (_) {
+        Object.defineProperty(global, name, { value, writable: true, configurable: true });
+    }
+}
+
+// Expose browser globals expected by THREE.js, jQuery, etc.
+setGlobal('window',            dom.window);
+setGlobal('document',          dom.window.document);
+setGlobal('navigator',         dom.window.navigator);
+setGlobal('HTMLElement',       dom.window.HTMLElement);
+setGlobal('HTMLCanvasElement', dom.window.HTMLCanvasElement);
+setGlobal('Image',             dom.window.Image);
+setGlobal('ImageData',         dom.window.ImageData);
+setGlobal('XMLHttpRequest',    dom.window.XMLHttpRequest);
+setGlobal('requestAnimationFrame',  (cb) => setTimeout(cb, 16));
+setGlobal('cancelAnimationFrame',   (id) => clearTimeout(id));
+setGlobal('ResizeObserver', class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+});
+
+// Stub WebGL context so THREE.WebGLRenderer does not crash on getContext()
+const canvasProto = dom.window.HTMLCanvasElement.prototype;
+const _origGetContext = canvasProto.getContext;
+canvasProto.getContext = function (type, ...args) {
+    if (type === 'webgl' || type === 'webgl2' || type === 'experimental-webgl') {
+        // Return a minimal WebGL stub that THREE can interrogate without causing
+        // errors.  Only the methods referenced during renderer initialisation
+        // need to be present.
+        return {
+            canvas: this,
+            drawingBufferWidth: 300,
+            drawingBufferHeight: 150,
+            getExtension: () => null,
+            getParameter: () => null,
+            getShaderPrecisionFormat: () => ({ rangeMin: 127, rangeMax: 127, precision: 23 }),
+            createTexture: () => ({}),
+            bindTexture: () => {},
+            texParameteri: () => {},
+            pixelStorei: () => {},
+            enable: () => {},
+            disable: () => {},
+            blendEquation: () => {},
+            blendFunc: () => {},
+            depthFunc: () => {},
+            depthMask: () => {},
+            colorMask: () => {},
+            clearColor: () => {},
+            clearDepth: () => {},
+            clearStencil: () => {},
+            scissor: () => {},
+            viewport: () => {},
+            clear: () => {},
+            useProgram: () => {},
+            frontFace: () => {},
+            cullFace: () => {},
+            createBuffer: () => ({}),
+            bindBuffer: () => {},
+            bufferData: () => {},
+            createFramebuffer: () => ({}),
+            bindFramebuffer: () => {},
+            createRenderbuffer: () => ({}),
+            bindRenderbuffer: () => {},
+            renderbufferStorage: () => {},
+            framebufferRenderbuffer: () => {},
+            framebufferTexture2D: () => {},
+            createProgram: () => ({}),
+            createShader: () => ({}),
+            shaderSource: () => {},
+            compileShader: () => {},
+            attachShader: () => {},
+            linkProgram: () => {},
+            getProgramParameter: (p, pname) => {
+                // LINK_STATUS
+                if (pname === 35714) return true;
+                return null;
+            },
+            getShaderParameter: () => true,
+            getUniformLocation: () => ({}),
+            getAttribLocation: () => 0,
+            uniform1i: () => {},
+            uniform1f: () => {},
+            uniform2f: () => {},
+            uniform3f: () => {},
+            uniform4f: () => {},
+            uniformMatrix3fv: () => {},
+            uniformMatrix4fv: () => {},
+            vertexAttribPointer: () => {},
+            enableVertexAttribArray: () => {},
+            disableVertexAttribArray: () => {},
+            drawArrays: () => {},
+            drawElements: () => {},
+            deleteBuffer: () => {},
+            deleteTexture: () => {},
+            deleteProgram: () => {},
+            deleteShader: () => {},
+            deleteFramebuffer: () => {},
+            deleteRenderbuffer: () => {},
+            isContextLost: () => false,
+            getError: () => 0,
+            // WebGL2 extras
+            createVertexArray: () => ({}),
+            bindVertexArray: () => {},
+            deleteVertexArray: () => {},
+            texImage2D: () => {},
+            texImage3D: () => {},
+            texStorage2D: () => {},
+            texStorage3D: () => {},
+            blitFramebuffer: () => {},
+            readBuffer: () => {},
+            drawBuffers: () => {},
+            renderbufferStorageMultisample: () => {},
+            createSampler: () => ({}),
+            deleteSampler: () => {},
+            bindSampler: () => {},
+            samplerParameteri: () => {},
+            samplerParameterf: () => {},
+        };
+    }
+    if (_origGetContext) {
+        return _origGetContext.call(this, type, ...args);
+    }
+    return null;
+};

--- a/test/visualizer.js
+++ b/test/visualizer.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * Tests for CrystVis.dispose() and the isDisposed guard.
+ *
+ * These tests run in Node.js (no DOM / WebGL) by constructing a CrystVis
+ * instance via Object.create so we can supply lightweight mock objects in
+ * place of the real THREE.WebGLRenderer and OrbitControls.
+ */
+
+import * as chai from 'chai';
+import { CrystVis } from '../lib/visualizer.js';
+
+const expect = chai.expect;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the bare minimum mock Renderer that dispose() expects to find on
+ * this._renderer.  Each call-count field starts at 0 so tests can assert
+ * that the matching method was called exactly once.
+ */
+function makeMockRenderer() {
+    const renderer = {
+        _disposed: false,
+        _disposeCalls: 0,
+        dispose() {
+            this._disposed = true;
+            this._disposeCalls++;
+        },
+        clear() {},
+        addNotifications() {},
+        clearNotifications() {},
+        resetOrbitCenter() {},
+        add() {},
+        remove() {},
+    };
+    return renderer;
+}
+
+/**
+ * Return a CrystVis instance whose constructor has been bypassed so that
+ * no DOM element or WebGL context is needed.  The internal _renderer is
+ * replaced with the supplied mock (or a fresh mock if none is given).
+ */
+function makeMockVis(mockRenderer) {
+    const r = mockRenderer || makeMockRenderer();
+
+    // Bypass the real constructor to avoid DOM / WebGL requirements
+    const vis = Object.create(CrystVis.prototype);
+
+    vis._isDisposed = false;
+    vis._renderer = r;
+    vis._loader = { load() { return {}; } };
+    vis._models = {};
+    vis._current_model = null;
+    vis._current_mname = null;
+    vis._displayed = null;
+    vis._selected = null;
+    vis._notifications = [];
+    vis._atom_click_events = {};
+    vis._atom_click_defaults = {};
+    vis._atom_box_event = null;
+    vis._hsel = false;
+    vis.cifsymtol = 1e-2;
+
+    return { vis, renderer: r };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: dispose()
+// ---------------------------------------------------------------------------
+
+describe('CrystVis#dispose', function () {
+
+    it('should set isDisposed to true', function () {
+        const { vis } = makeMockVis();
+        expect(vis.isDisposed).to.be.false;
+        vis.dispose();
+        expect(vis.isDisposed).to.be.true;
+    });
+
+    it('should call renderer.dispose() exactly once', function () {
+        const { vis, renderer } = makeMockVis();
+        vis.dispose();
+        expect(renderer._disposeCalls).to.equal(1);
+    });
+
+    it('should null the internal _renderer reference', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(vis._renderer).to.be.null;
+    });
+
+    it('should null _current_model and _current_mname', function () {
+        const { vis } = makeMockVis();
+        vis._current_mname = 'test';
+        vis.dispose();
+        expect(vis._current_model).to.be.null;
+        expect(vis._current_mname).to.be.null;
+    });
+
+    it('should clear the _models map', function () {
+        const { vis } = makeMockVis();
+        vis._models = { a: {}, b: {} };
+        vis.dispose();
+        expect(Object.keys(vis._models)).to.have.length(0);
+    });
+
+    it('should clear atom event callbacks', function () {
+        const { vis } = makeMockVis();
+        vis._atom_click_events = { 1: () => {} };
+        vis._atom_box_event = () => {};
+        vis.dispose();
+        expect(Object.keys(vis._atom_click_events)).to.have.length(0);
+        expect(vis._atom_box_event).to.be.null;
+    });
+
+    it('should be idempotent: calling dispose() twice is harmless', function () {
+        const { vis, renderer } = makeMockVis();
+        vis.dispose();
+        vis.dispose();
+        // renderer.dispose() should only have been called the first time
+        expect(renderer._disposeCalls).to.equal(1);
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Tests: isDisposed guard
+// ---------------------------------------------------------------------------
+
+describe('CrystVis#isDisposed guard', function () {
+
+    it('loadModels() should throw after disposal', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(() => vis.loadModels('data', 'xyz')).to.throw(
+            /cannot call loadModels\(\) on a disposed instance/
+        );
+    });
+
+    it('displayModel() should throw after disposal', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(() => vis.displayModel('mymodel')).to.throw(
+            /cannot call displayModel\(\) on a disposed instance/
+        );
+    });
+
+    it('reloadModel() should throw after disposal', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(() => vis.reloadModel('mymodel')).to.throw(
+            /cannot call reloadModel\(\) on a disposed instance/
+        );
+    });
+
+    it('isDisposed getter returns false before disposal', function () {
+        const { vis } = makeMockVis();
+        expect(vis.isDisposed).to.be.false;
+    });
+
+    it('isDisposed getter returns true after disposal', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(vis.isDisposed).to.be.true;
+    });
+
+});


### PR DESCRIPTION
## Summary

Adds a `dispose()` teardown method to `CrystVis` so React and anywidget hosts can cleanly unmount a visualiser without leaking the WebGL context, orphaned event listeners, or a running animation loop.

## Problem

`CrystVis` held several resources that had no cleanup path:
- A `THREE.WebGLRenderer` (and its WebGL context) that lived forever
- A running `requestAnimationFrame` loop
- Event listeners on the canvas registered by `OrbitControls`, the raycaster, and `SelectionHelper`
- A `ResizeObserver` watching the container element

In frameworks that mount/unmount components (React, anywidget, etc.) this caused context leaks and "too many active WebGL contexts" warnings after repeated remounts.

## Changes

### `lib/selbox.js`
- `SelectionHelper` now registers its `pointerdown / pointermove / pointerup / keyup` listeners via an `AbortController` instead of individual `addEventListener` calls.
- New `SelectionHelper.prototype.dispose()` — aborts the controller (removes all four listeners in one call) and removes the overlay `<div>` from the DOM.

### `lib/render.js`
- `_animate()` stores the `requestAnimationFrame` return value in `this._animFrameId` so it can be cancelled.
- The raycaster's `pointerdown` handler is stored as `this._boundRaycastClick` so it can be removed by reference.
- New `Renderer.dispose()` — cancels the rAF loop, removes the raycaster listener, calls `OrbitControls.dispose()`, calls `SelectionHelper.dispose()`, disconnects the `ResizeObserver`, then calls `THREE.WebGLRenderer.dispose()` and removes the canvas from the DOM.

### `lib/visualizer.js`
- `dispose()` — delegates to `Renderer.dispose()`, nulls all internal refs (`_renderer`, `_models`, `_current_model`, `_displayed`, `_selected`, callbacks, notifications). Safe to call multiple times.
- `isDisposed` — read-only boolean getter.
- `loadModels()`, `reloadModel()`, `displayModel()` — each throws a clear `Error` if called after disposal instead of crashing silently.

### Tests & infrastructure
- `test/visualizer.js` — 12 new Mocha tests covering `dispose()` behaviour and the `isDisposed` guard; uses a mock renderer so no DOM or WebGL context is required.
- `test/setup-dom.cjs` — jsdom bootstrap (`--require` hook) that stubs `window`, `document`, `HTMLCanvasElement.getContext('webgl')`, `requestAnimationFrame`, and `ResizeObserver` so the full suite runs in Node.js without a browser.
- `.mocharc.yml` — wires the setup hook in and pins the spec glob to `test/*.js`.

## Usage

```js
const vis = new CrystVis('#container');
vis.loadModels(data, 'cif');

// later, on unmount:
vis.dispose();          // cleans up WebGL context, listeners, rAF loop
console.log(vis.isDisposed); // true

vis.loadModels(data, 'cif'); // throws: "cannot call loadModels() on a disposed instance"