### PR TITLE
feat(magres): parse and visualise hyperfine tensors from magres_old blocks

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -33,14 +33,3 @@
     box-sizing: border-box;
     cursor: pointer;
 }
-
-#colorgrid {
-    display: grid;
-    grid-template-rows: repeat(10, 1fr);
-    grid-template-columns: repeat(30, 1fr);
-
-    width: 300px;
-    height: 300px;
-
-    background-color: #000000;
-}

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,7 +54,12 @@
                                 <input id="label-check" type="checkbox" name="" value="false" onchange="changeLabels()">Show labels
                             </td>
                             <td colspan="" rowspan="" headers="">
-                                <input id="ellipsoid-check" type="checkbox" name="" value="false" onchange="changeEllipsoids()">Show ellipsoids
+                                <input id="ellipsoid-check" type="checkbox" name="" value="false" onchange="changeEllipsoids()">Show MS ellipsoids
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="" rowspan="" headers="">
+                                <input id="hf-ellipsoid-check" type="checkbox" name="" value="false" onchange="changeHFEllipsoids()">Show HF ellipsoids
                             </td>
                         </tr>
                         <tr>

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,17 +54,19 @@
                                 <input id="label-check" type="checkbox" name="" value="false" onchange="changeLabels()">Show labels
                             </td>
                             <td colspan="" rowspan="" headers="">
-                                <input id="ellipsoid-check" type="checkbox" name="" value="false" onchange="changeEllipsoids()">Show MS ellipsoids
+                                <input id="ellipsoid-check" type="checkbox" name="" value="false" onchange="changeEllipsoids()" disabled>Show MS ellipsoids<br>
+                                Scale: <input id="ms-scale" type="range" min="0.001" max="0.5" step="0.001" value="0.05" oninput="changeMsScale()" disabled> <span id="ms-scale-val">0.050</span>
                             </td>
                         </tr>
                         <tr>
                             <td colspan="" rowspan="" headers="">
-                                <input id="hf-ellipsoid-check" type="checkbox" name="" value="false" onchange="changeHFEllipsoids()">Show HF ellipsoids
+                                <input id="hf-ellipsoid-check" type="checkbox" name="" value="false" onchange="changeHFEllipsoids()" disabled>Show HF ellipsoids<br>
+                                Scale: <input id="hf-scale" type="range" min="0.001" max="1.0" step="0.001" value="0.1" oninput="changeHfScale()" disabled> <span id="hf-scale-val">0.100</span>
                             </td>
                         </tr>
                         <tr>
                           <td>
-                            <input id="isosurf-check" type="checkbox" name="" value="false" onchange="changeIsosurface()">Show isosurface
+                            <input id="isosurf-check" type="checkbox" name="" value="false" onchange="changeIsosurface()" disabled>Show isosurface
                           </td>
                           <td>
                               <input type="text" id="vdw-f" size="5" value="1.0"> Van der Waals scaling
@@ -86,9 +88,6 @@
                         </tr>
                    </tbody>
            </table> 
-           <div id='colorgrid'>
-               
-           </div>
         </div>
 
     </div>

--- a/demo/main.js
+++ b/demo/main.js
@@ -3,44 +3,9 @@
 const CrystVis = require('../lib/visualizer.js').CrystVis;
 const Primitives = require('../lib/primitives/index.js');
 
-const shiftCpkColor = require('../lib/utils').shiftCpkColor;
-
 var visualizer = new CrystVis('#main-app', 0, 0);
 visualizer.highlight_selected = true;
 visualizer.theme = 'dark';
-
-// Generate color grid (for testing shiftCpkColor)
-const gridEl = document.getElementById('colorgrid');
-const gridSize = 10;
-
-function int2hex(c) {
-    c = c.toString(16);
-    return '0'.repeat(6-c.length) + c;
-}
-
-for (let i = 0; i < gridSize; ++i) {
-    for (let j = 0; j < gridSize; ++j) {
-
-        const hue = parseInt(j/gridSize*360);
-        const light = parseInt(i/(gridSize-1)*100);
-        const cbase = `hsl(${hue}, 100%, ${light}%)`;
-        const cplus = shiftCpkColor(cbase, 1.0);
-        const cminus = shiftCpkColor(cbase, -1.0);
-
-        let el = document.createElement('div');
-        el.style['background-color'] = '#' + int2hex(cminus);
-        gridEl.append(el);
-
-        el = document.createElement('div');
-        el.style['background-color'] = cbase;
-        gridEl.append(el);
-
-        el = document.createElement('div');
-        el.style['background-color'] = '#' + int2hex(cplus);
-        gridEl.append(el);
-
-    }
-}
 
 function showError(msg) {
     var banner = document.getElementById('error-banner');
@@ -86,6 +51,32 @@ window.loadFile = function() {
             'all': []
         });
 
+        // Update checkbox/slider states based on available data in the loaded model
+        var model = visualizer.model;
+
+        var ellipsoidCheck = document.getElementById('ellipsoid-check');
+        var msSlider = document.getElementById('ms-scale');
+        var hasMs = model.hasArray('ms');
+        ellipsoidCheck.disabled = !hasMs;
+        msSlider.disabled = !hasMs;
+        if (!hasMs && ellipsoidCheck.checked) {
+            ellipsoidCheck.checked = false;
+            visualizer.displayed.removeEllipsoids('ms');
+        }
+
+        var hfEllipsoidCheck = document.getElementById('hf-ellipsoid-check');
+        var hfSlider = document.getElementById('hf-scale');
+        var hasHf = model.hasArray('hf');
+        hfEllipsoidCheck.disabled = !hasHf;
+        hfSlider.disabled = !hasHf;
+        if (!hasHf && hfEllipsoidCheck.checked) {
+            hfEllipsoidCheck.checked = false;
+            visualizer.displayed.removeEllipsoids('hf');
+        }
+
+        // Isosurface only makes sense once a model (with a cell) is loaded
+        document.getElementById('isosurf-check').disabled = false;
+
     };
 }
 
@@ -107,23 +98,31 @@ window.changeLabels = function() {
 
 window.changeEllipsoids = function() {
     var val = document.getElementById('ellipsoid-check').checked;
+    var scale = parseFloat(document.getElementById('ms-scale').value);
     if (val) {
         visualizer.displayed.find({
             'elements': 'H'
         }).addEllipsoids((a) => {
             return a.getArrayValue('ms');
         }, 'ms', {
-            scalingFactor: 0.05,
+            scalingFactor: scale,
             opacity: 0.2
         });
-
     } else {
         visualizer.displayed.removeEllipsoids('ms');
     }
 }
 
+window.changeMsScale = function() {
+    document.getElementById('ms-scale-val').textContent = parseFloat(document.getElementById('ms-scale').value).toFixed(3);
+    if (document.getElementById('ellipsoid-check').checked) {
+        window.changeEllipsoids();
+    }
+}
+
 window.changeHFEllipsoids = function() {
     var val = document.getElementById('hf-ellipsoid-check').checked;
+    var scale = parseFloat(document.getElementById('hf-scale').value);
     if (val) {
         // Show HF (hyperfine) tensor ellipsoids for all atoms that have data
         visualizer.displayed.addEllipsoids((a) => {
@@ -133,11 +132,18 @@ window.changeHFEllipsoids = function() {
                 return null;
             }
         }, 'hf', {
-            scalingFactor: 0.1,
+            scalingFactor: scale,
             opacity: 0.3
         });
     } else {
         visualizer.displayed.removeEllipsoids('hf');
+    }
+}
+
+window.changeHfScale = function() {
+    document.getElementById('hf-scale-val').textContent = parseFloat(document.getElementById('hf-scale').value).toFixed(3);
+    if (document.getElementById('hf-ellipsoid-check').checked) {
+        window.changeHFEllipsoids();
     }
 }
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -122,6 +122,25 @@ window.changeEllipsoids = function() {
     }
 }
 
+window.changeHFEllipsoids = function() {
+    var val = document.getElementById('hf-ellipsoid-check').checked;
+    if (val) {
+        // Show HF (hyperfine) tensor ellipsoids for all atoms that have data
+        visualizer.displayed.addEllipsoids((a) => {
+            try {
+                return a.getArrayValue('hf');
+            } catch(e) {
+                return null;
+            }
+        }, 'hf', {
+            scalingFactor: 0.1,
+            opacity: 0.3
+        });
+    } else {
+        visualizer.displayed.removeEllipsoids('hf');
+    }
+}
+
 var isosurface = null;
 window.changeIsosurface = function() {
     var val = document.getElementById('isosurf-check').checked;

--- a/lib/formats/magres.js
+++ b/lib/formats/magres.js
@@ -120,6 +120,146 @@ const MagresParsers = {
     isc: parseTwoAtomLine
 };
 
+/**
+ * Parse the magres_old block to extract hyperfine (HF) tensors and the
+ * magnetogyric ratios table.
+ *
+ * The magres_old block is free-text output produced by older CASTEP versions.
+ * Each atom section looks like:
+ *
+ *   ============
+ *   Atom: H        1
+ *   ============
+ *   H        1 Coordinates  ...
+ *
+ *   TOTAL tensor
+ *
+ *      a11   a12   a13
+ *      a21   a22   a23
+ *      a31   a32   a33
+ *
+ *   H        1 Eigenvalue  A_xx  ...
+ *   ...
+ *   H        1 Iso:  ... (MHz)
+ *
+ * The tensor values are in MHz.
+ *
+ * The header table looks like either:
+ *   H      Isotope   1             GAMMA =  2.6752E+08 rad T-1 s-1
+ *   H:Mu    User defined.            GAMMA =  8.5162E+08 rad T-1 s-1
+ *
+ * @param {string}  text        Contents of the magres_old block
+ * @param {Array}   mlabels     Array of [species, index] pairs for each atom
+ * @param {int}     N           Number of atoms
+ * @returns {Object}            { hf_data: Array<TensorData|null>,
+ *                                gamma_ratios: Object<string, {isotope, gamma}> }
+ */
+function parseMagresOldBlock(text, mlabels, N) {
+    const lines = text.split('\n');
+    const hf_data = new Array(N).fill(null);
+    const gamma_ratios = {};   // species label → { isotope: int|null, gamma: float }
+
+    let current_sp = null;
+    let current_idx = null;
+    // 'idle' | 'reading_rows' | 'waiting_eigenvalue_label'
+    let state = 'idle';
+    let tensor_rows = [];
+    let pending_tensor = null;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+
+        // Parse magnetogyric ratio table lines:
+        //   "H      Isotope   1             GAMMA =  2.6752E+08 rad T-1 s-1"
+        //   "H:Mu    User defined.            GAMMA =  8.5162E+08 rad T-1 s-1"
+        const gamma_iso_match = line.match(/^(\S+)\s+Isotope\s+(\d+)\s+GAMMA\s*=\s*([+-]?[\d.]+E[+-]?\d+)/i);
+        if (gamma_iso_match) {
+            gamma_ratios[gamma_iso_match[1]] = {
+                isotope: parseInt(gamma_iso_match[2]),
+                gamma: parseFloat(gamma_iso_match[3])
+            };
+            continue;
+        }
+        const gamma_user_match = line.match(/^(\S+)\s+User defined\.\s+GAMMA\s*=\s*([+-]?[\d.]+E[+-]?\d+)/i);
+        if (gamma_user_match) {
+            gamma_ratios[gamma_user_match[1]] = {
+                isotope: null,
+                gamma: parseFloat(gamma_user_match[2])
+            };
+            continue;
+        }
+
+        // Look for "Atom: ELEM INDEX"
+        const atom_match = line.match(/^Atom:\s+(\S+)\s+(\d+)$/);
+        if (atom_match) {
+            current_sp = atom_match[1];
+            current_idx = parseInt(atom_match[2]);
+            state = 'idle';
+            tensor_rows = [];
+            pending_tensor = null;
+            continue;
+        }
+
+        // Look for the "TOTAL tensor" header (exact match – not "TOTAL Shielding Tensor" etc.)
+        if (line === 'TOTAL tensor') {
+            state = 'reading_rows';
+            tensor_rows = [];
+            pending_tensor = null;
+            continue;
+        }
+
+        if (state === 'reading_rows' && current_sp !== null) {
+            if (line === '') continue;
+
+            const parts = line.split(/\s+/).filter(s => s !== '');
+            const nums = parts.map(parseFloat);
+
+            if (nums.length === 3 && nums.every(n => !isNaN(n))) {
+                tensor_rows.push(nums);
+                if (tensor_rows.length === 3) {
+                    // Matrix complete – wait for Eigenvalue label to confirm it's HF
+                    pending_tensor = tensor_rows.slice();
+                    state = 'waiting_eigenvalue_label';
+                    tensor_rows = [];
+                }
+            } else {
+                // Unexpected non-numeric line – abort
+                state = 'idle';
+                tensor_rows = [];
+            }
+            continue;
+        }
+
+        if (state === 'waiting_eigenvalue_label' && current_sp !== null) {
+            if (line === '') continue;
+
+            // Look for "SPECIES INDEX Eigenvalue LABEL VALUE"
+            // HF tensors use A_xx / A_yy / A_zz.
+            // EFG uses V_xx, shielding uses sigma_xx – we skip those.
+            const eval_match = line.match(/Eigenvalue\s+(\S+)/);
+            if (eval_match) {
+                const label = eval_match[1]; // e.g. A_xx, V_xx, sigma_xx
+                if (label.startsWith('A_')) {
+                    // Confirmed hyperfine – store the tensor
+                    const idx = _.findIndex(mlabels, x =>
+                        x[0] === current_sp && x[1] === current_idx
+                    );
+                    if (idx >= 0) {
+                        hf_data[idx] = new TensorData(pending_tensor);
+                    }
+                }
+                // Any other label (V_xx, sigma_xx, …) – silently discard
+                state = 'idle';
+                pending_tensor = null;
+            }
+            // Non-eigenvalue lines (could be blank) – keep waiting
+            continue;
+        }
+    }
+
+    return { hf_data, gamma_ratios };
+}
+
 function load(contents, filename='magres') {
 
     const known_blocks = ['atoms', 'magres'];
@@ -275,7 +415,10 @@ function load(contents, filename='magres') {
         for (let i = 0; i < ablock.atom.lines.length; ++i) {
             let l = ablock.atom.lines[i];
 
-            elems.push(l[0]);
+            // CASTEP custom species use the form ELEMENT:LABEL (e.g. H:Mu).
+            // Strip the colon-suffix to recover a valid element symbol while
+            // keeping the full species identifier in mlabels/labels for lookup.
+            elems.push(l[0].split(':')[0]);
             mlabels.push([l[1], parseInt(l[2])]);
             labels.push(l[1]);
             pos.push(_.map(l.slice(3,6), function(x) {
@@ -358,6 +501,18 @@ function load(contents, filename='magres') {
 
         }
 
+    }
+
+    // Parse hyperfine tensors and gamma ratios from magres_old block
+    const magres_old_text = blocks['magres_old'];
+    if (magres_old_text && typeof magres_old_text === 'string') {
+        const { hf_data, gamma_ratios } = parseMagresOldBlock(magres_old_text, mlabels, N);
+        if (hf_data.some(d => d !== null)) {
+            atoms.set_array('hf', hf_data);
+        }
+        if (Object.keys(gamma_ratios).length > 0) {
+            atoms.info['hf-gyromagnetic-ratios'] = gamma_ratios;
+        }
     }
 
     let structs = {};

--- a/test/data/hf_mu_test.magres
+++ b/test/data/hf_mu_test.magres
@@ -1,0 +1,62 @@
+#$magres-abinitio-v1.0
+# Synthetic magres file for testing H:Mu custom-species handling
+[calculation]
+calc_code CASTEP
+calc_code_version 25.1
+calc_pspot H:Mu 1|0.6|13|15|17|10(qc=8)
+[/calculation]
+[atoms]
+units lattice Angstrom
+lattice          1.0000000000000000E+01          0.0000000000000000E+00          0.0000000000000000E+00          0.0000000000000000E+00          1.0000000000000000E+01          0.0000000000000000E+00          0.0000000000000000E+00          0.0000000000000000E+00          1.0000000000000000E+01
+units atom Angstrom
+atom H       H    1          1.0000000000000000E+00          2.0000000000000000E+00          3.0000000000000000E+00
+atom H:Mu    H:Mu 1          4.0000000000000000E+00          5.0000000000000000E+00          6.0000000000000000E+00
+[/atoms]
+[magres]
+[/magres]
+[magres_old]
+==========================================================================
+  Using the following values of the magnetogyric ratio                    
+  H      Isotope   1             GAMMA =  2.6752E+08 rad T-1 s-1
+  H:Mu    User defined.            GAMMA =  8.5162E+08 rad T-1 s-1
+==========================================================================
+
+============
+Atom: H        1
+============
+H        1 Coordinates      1.000    2.000    3.000   A
+
+TOTAL tensor
+
+               1.0000      0.0000      0.0000
+               0.0000      2.0000      0.0000
+               0.0000      0.0000      3.0000
+
+H        1 Eigenvalue  A_xx       1.0000      
+H        1 Eigenvector A_xx       1.0000      0.0000      0.0000
+H        1 Eigenvalue  A_yy       2.0000      
+H        1 Eigenvector A_yy       0.0000      1.0000      0.0000
+H        1 Eigenvalue  A_zz       3.0000      
+H        1 Eigenvector A_zz       0.0000      0.0000      1.0000
+
+H        1 Iso:        2.0000 (MHz)
+============
+Atom: H:Mu     1
+============
+H:Mu     1 Coordinates      4.000    5.000    6.000   A
+
+TOTAL tensor
+
+             -10.0000      1.0000      0.0000
+               1.0000     -20.0000      0.0000
+               0.0000      0.0000     -30.0000
+
+H:Mu     1 Eigenvalue  A_xx     -10.0000      
+H:Mu     1 Eigenvector A_xx       1.0000      0.0000      0.0000
+H:Mu     1 Eigenvalue  A_yy     -20.0000      
+H:Mu     1 Eigenvector A_yy       0.0000      1.0000      0.0000
+H:Mu     1 Eigenvalue  A_zz     -30.0000      
+H:Mu     1 Eigenvector A_zz       0.0000      0.0000      1.0000
+
+H:Mu     1 Iso:       -20.0000 (MHz)
+[/magres_old]

--- a/test/data/hf_test.magres
+++ b/test/data/hf_test.magres
@@ -1,0 +1,61 @@
+#$magres-abinitio-v1.0
+# Synthetic magres file for testing HF tensor parsing from magres_old block
+[calculation]
+calc_code CASTEP
+calc_code_version 25.1
+[/calculation]
+[atoms]
+units lattice Angstrom
+lattice          1.0000000000000000E+01          0.0000000000000000E+00          0.0000000000000000E+00          0.0000000000000000E+00          1.0000000000000000E+01          0.0000000000000000E+00          0.0000000000000000E+00          0.0000000000000000E+00          1.0000000000000000E+01
+units atom Angstrom
+atom H       H   1          1.0000000000000000E+00          2.0000000000000000E+00          3.0000000000000000E+00
+atom C       C   1          4.0000000000000000E+00          5.0000000000000000E+00          6.0000000000000000E+00
+[/atoms]
+[magres]
+[/magres]
+[magres_old]
+==========================================================================
+  Using the following values of the magnetogyric ratio
+  H      Isotope   1             GAMMA =  2.6752E+08 rad T-1 s-1
+  C      Isotope  13             GAMMA =  6.7283E+07 rad T-1 s-1
+==========================================================================
+
+============
+Atom: H        1
+============
+H        1 Coordinates      1.000    2.000    3.000   A
+
+TOTAL tensor
+
+               1.2345     -0.5678      0.1234
+              -0.5678      2.3456      0.4567
+               0.1234      0.4567      3.4567
+
+H        1 Eigenvalue  A_xx       0.9985
+H        1 Eigenvector A_xx       0.9730      0.2304     -0.0220
+H        1 Eigenvalue  A_yy       2.4022
+H        1 Eigenvector A_yy      -0.2282      0.9623      0.1486
+H        1 Eigenvalue  A_zz       3.6361
+H        1 Eigenvector A_zz       0.0530     -0.1432      0.9884
+
+H        1 Iso:        2.3456 (MHz)
+============
+Atom: C        1
+============
+C        1 Coordinates      4.000    5.000    6.000   A
+
+TOTAL tensor
+
+               5.0000      1.0000      0.0000
+               1.0000      5.0000      0.0000
+               0.0000      0.0000      3.0000
+
+C        1 Eigenvalue  A_xx       3.0000
+C        1 Eigenvector A_xx       0.0000      0.0000      1.0000
+C        1 Eigenvalue  A_yy       4.0000
+C        1 Eigenvector A_yy      -0.7071      0.7071      0.0000
+C        1 Eigenvalue  A_zz       6.0000
+C        1 Eigenvector A_zz       0.7071      0.7071      0.0000
+
+C        1 Iso:        4.3333 (MHz)
+[/magres_old]

--- a/test/data/optimized_muon_65-hf.magres
+++ b/test/data/optimized_muon_65-hf.magres
@@ -1,0 +1,1424 @@
+#$magres-abinitio-v1.0
+# See http://www.ccpnc.ac.uk/pmwiki.php/CCPNC/Fileformat for format definition and code samples and libraries
+[calculation]
+calc_code CASTEP
+calc_code_version  25.1
+calc_code_hgversion a000408f0  Castep251_branch  Tue Mar 11 13:44:46 2025 +0000     
+calc_code_platform linux_x86_64_gfortran10                                         
+calc_name optimized_muon_65-hf
+calc_comment                                                                                 
+calc_xcfunctional RSCAN 
+calc_cutoffenergy    800.00000000 eV
+calc_pspot H 1|0.6|13|15|17|10(qc=8)
+calc_pspot C 2|1.4|10|12|13|20:21(qc=7)
+calc_pspot N 2|1.1|14|16|18|20:21(qc=7)
+calc_pspot O 2|1.1|17|20|23|20:21(qc=8)
+calc_pspot S 3|1.8|5|6|7|30:31:32
+calc_pspot Fe 3|2.4|2.4|1.0|8|9|10|40:41:32U2U2(qc=5.5)
+calc_pspot Br 2|2.0|5|6|7|40:41(qc=6)
+calc_pspot H:Mu 1|0.6|13|15|17|10(qc=8)
+calc_kpoint_mp_grid 2 1 1
+calc_kpoint_mp_offset       0.00000000      0.00000000      0.00000000
+[/calculation]
+[atoms]
+units lattice Angstrom
+lattice           7.6921999999999997E+00          0.0000000000000000E+00          0.0000000000000000E+00          1.7840530000000001E+00          1.0675960000000000E+01          0.0000000000000000E+00          7.2313499999999997E-01          2.9434380000000000E+00          1.0810124000000000E+01
+units atom Angstrom
+symmetry x,y,z
+atom H       H   1          6.2085837924378007E+00          5.3689841463473043E+00          1.0055955196099164E+01
+atom H       H   2          7.4769626639259190E+00          4.5528394483962069E+00          1.0972606923550584E+01
+atom H       H   3          8.4335335257950845E+00          7.8775470815923363E+00          8.7217235651529812E+00
+atom H       H   4          6.8314057233713594E+00          7.1481308130603018E+00          8.5659424703085492E+00
+atom H       H   5          1.0367629576644893E+01          7.3048180903782454E+00          8.9406160046700709E+00
+atom H       H   6          8.6209432884356083E+00          5.3484113694846558E+00          1.2349385512559211E+01
+atom H       H   7          1.1881121022841237E+01          8.2122960132480269E+00          1.0775669638091966E+01
+atom H       H   8          1.0768719120330996E+01          5.4177151893483613E+00          1.3523370419654364E+01
+atom H       H   9          4.0126531527181628E+00          8.0868607199679730E+00          7.8289967446584752E-01
+atom H       H  10          2.8217312795083318E+00          8.9431025458116196E+00         -1.9815879893475816E-01
+atom H       H  11          1.6464264408507294E+00          5.7001823815988386E+00          2.0794995103267340E+00
+atom H       H  12          3.2790782537731631E+00          6.3503543918427141E+00          2.2357903516308171E+00
+atom H       H  13         -2.6053014580173439E-01          6.2630436398383740E+00          1.7394575600436997E+00
+atom H       H  14          1.6263940612296166E+00          8.2555158404057192E+00         -1.5713428637588731E+00
+atom H       H  15         -2.3026480082494278E+00          6.1163582020015861E+00          4.6920547133321605E-01
+atom H       H  16         -4.6748036981709101E-01          8.1763095969846962E+00         -2.8023255055072984E+00
+atom C       C   1          5.9202445360696760E+00          3.0633408688120753E+00          6.4316367465408160E+00
+atom C       C   2          7.2351757188095123E+00          4.6992295663764603E+00          4.9794751383743900E+00
+atom C       C   3          5.4861270697977975E+00          5.6316054493707330E+00          6.8372215851037561E+00
+atom C       C   4          7.2587552824031158E+00          5.0804587393722764E+00          1.0052708693188791E+01
+atom C       C   5          7.8910341203785386E+00          6.9375251815098897E+00          8.7009605086189890E+00
+atom C       C   6          8.9129295783910596E+00          2.2712984469131405E+00          7.0568859362649219E+00
+atom C       C   7          1.0494228520076593E+01          3.8630118455705440E+00          8.6033644207320368E+00
+atom C       C   8          1.0152534325035113E+01          4.2099530844619562E+00          6.0143920626930463E+00
+atom C       C   9          9.3504972766525700E+00          6.2923790131146209E+00          1.0532449197341911E+01
+atom C       C  10          1.0412384872300807E+01          6.9233690311418794E+00          9.9480009487525027E+00
+atom C       C  11          9.4744941583454576E+00          5.7667520592276595E+00          1.1843960316411831E+01
+atom C       C  12          1.1701701347457588E+01          7.1312008500092601E+00          1.0656462640598075E+01
+atom C       C  13          1.0693498021660487E+01          5.8368874435747200E+00          1.2532322581056327E+01
+atom C       C  14          1.1762039733751795E+01          6.4591782861143567E+00          1.1971905888458817E+01
+atom C       C  15          4.2864533721464548E+00          1.0493533060853970E+01          4.3131512321397292E+00
+atom C       C  16          2.9760927394391055E+00          8.8751413298893898E+00          5.8072110410628319E+00
+atom C       C  17          4.7071654082798915E+00          7.8962641319511606E+00          3.9213235811925609E+00
+atom C       C  18          2.9779186938427755E+00          8.4282009026876228E+00          7.4120569740779274E-01
+atom C       C  19          2.2312264458938311E+00          6.6140631706174808E+00          2.0966644265536960E+00
+atom C       C  20          1.3097693641439427E+00          1.1318980581793854E+01          3.7132130601280235E+00
+atom C       C  21         -2.4463903970578679E-01          9.7350742508520334E+00          2.1431825851764823E+00
+atom C       C  22          5.4867372042631979E-02          9.3954290203943618E+00          4.7602065734297794E+00
+atom C       C  23          8.5570750234095649E-01          7.3018845049348151E+00          2.0107026943653947E-01
+atom C       C  24         -2.7209703828441217E-01          6.6836691199490712E+00          7.4643300310140515E-01
+atom C       C  25          7.6188483558412534E-01          7.8287630365623047E+00         -1.0902144594943639E+00
+atom C       C  26         -1.4535131587383099E+00          6.6154041160826322E+00          2.8620823715340183E-02
+atom C       C  27         -4.2057065635842961E-01          7.7758471455255602E+00         -1.8023237188148833E+00
+atom C       C  28         -1.5287293654080256E+00          7.1753583294202334E+00         -1.2325221174022432E+00
+atom N       N   1          8.0985894930795119E+00          6.2148980308025754E+00          9.8976320986070885E+00
+atom N       N   2          2.0748885504685264E+00          7.3393354060696323E+00          8.8965631280043311E-01
+atom O       O   1          5.2888691119458660E+00          2.1192160740217170E+00          6.2907045373571844E+00
+atom O       O   2          7.5131757838741802E+00          4.7853454549673859E+00          3.8730325482960049E+00
+atom O       O   3          4.6203091271406338E+00          6.3798714403042922E+00          6.9173680668721236E+00
+atom O       O   4          8.6854129759555168E+00          1.1795259911427738E+00          6.7897535369965869E+00
+atom O       O   5          1.1388061330755420E+01          3.7142889528442091E+00          9.3056456608898834E+00
+atom O       O   6          1.0786488532692600E+01          4.3731132855303994E+00          5.0765529630934099E+00
+atom O       O   7          4.8992751507544181E+00          1.1455272220051997E+01          4.4125737501182352E+00
+atom O       O   8          2.6908757687264919E+00          8.8182132140626202E+00          6.9139349441306379E+00
+atom O       O   9          5.5571755990993710E+00          7.1340574708702800E+00          3.8100702235832711E+00
+atom O       O  10          1.5163494365871528E+00          1.2412520132731673E+01          3.9895033747068158E+00
+atom O       O  11         -1.1034600440471551E+00          9.8859008044802223E+00          1.4009332121591052E+00
+atom O       O  12         -5.7790297126757884E-01          9.2357345355343821E+00          5.7001186591485364E+00
+atom S       S   1          7.3386633406894974E+00          3.7574288512154026E+00          8.7513694624995626E+00
+atom S       S   2          8.4305345846152839E+00          6.0886321648188195E+00          7.1306627160268459E+00
+atom S       S   3          2.8925571163288408E+00          9.7774211815363046E+00          2.0192671622718388E+00
+atom S       S   4          1.7437207500913006E+00          7.4921712260692077E+00          3.6632361792005699E+00
+atom Fe      Fe   1          6.8492139831271208E+00          4.5394333906822428E+00          6.6901332877529089E+00
+atom Fe      Fe   2          9.1589415568277595E+00          3.9598074577735090E+00          7.4443284120743174E+00
+atom Fe      Fe   3          3.3593918527037316E+00          9.0095051236152752E+00          4.0886162368886181E+00
+atom Fe      Fe   4          1.0620718749274967E+00          9.6268565915732864E+00          3.3304338560517008E+00
+atom Br      Br   1          1.3393915195074584E+01          6.6040918900277088E+00          1.2922892379126585E+01
+atom Br      Br   2         -3.1530538822446950E+00          7.0783945020655414E+00         -2.2179251973449778E+00
+atom H:Mu    H:Mu   1          4.8426793677503879E+00          6.8201375698180877E+00          1.0011986825237489E+01
+[/atoms]
+[magres]
+[/magres]
+[magres_old]
+==========================================================================
+  Using the following values of the magnetogyric ratio                    
+  H      Isotope   1             GAMMA =  2.6752E+08 rad T-1 s-1
+  C      Isotope  13             GAMMA =  6.7283E+07 rad T-1 s-1
+  N      Isotope  15             GAMMA = -2.7126E+07 rad T-1 s-1
+  O      Isotope  17             GAMMA = -3.6281E+07 rad T-1 s-1
+  S      Isotope  33             GAMMA =  2.0557E+07 rad T-1 s-1
+  Fe     Isotope  57             GAMMA =  8.6806E+06 rad T-1 s-1
+  Br     Isotope  81             GAMMA =  7.2498E+07 rad T-1 s-1
+  H:Mu    User defined.            GAMMA =  8.5162E+08 rad T-1 s-1
+==========================================================================
+
+============
+Atom: H        1
+============
+H        1 Coordinates      6.209    5.369   10.056   A
+
+TOTAL tensor
+
+              -2.5897      2.2293      0.4459
+               2.2293      0.8275     -0.5108
+               0.4459     -0.5108      0.9140
+
+H        1 Eigenvalue  A_xx       0.9306      
+H        1 Eigenvector A_xx       0.2275      0.1674      0.9593
+H        1 Eigenvalue  A_yy       1.9948      
+H        1 Eigenvector A_yy      -0.4038     -0.8802      0.2494
+H        1 Eigenvalue  A_zz      -3.7736      
+H        1 Eigenvector A_zz       0.8861     -0.4441     -0.1327
+
+H        1 Iso:       -0.2827 (MHz)
+============
+Atom: H        2
+============
+H        2 Coordinates      7.477    4.553   10.973   A
+
+TOTAL tensor
+
+              -4.0759     -0.8354     -1.9220
+              -0.8354      1.2096     -1.0705
+              -1.9220     -1.0705      2.0437
+
+H        2 Eigenvalue  A_xx       1.0201      
+H        2 Eigenvector A_xx       0.2874     -0.8792     -0.3799
+H        2 Eigenvalue  A_yy       2.9895      
+H        2 Eigenvector A_yy      -0.1868     -0.4405      0.8781
+H        2 Eigenvalue  A_zz      -4.8323      
+H        2 Eigenvector A_zz      -0.9394     -0.1814     -0.2908
+
+H        2 Iso:       -0.2742 (MHz)
+============
+Atom: H        3
+============
+H        3 Coordinates      8.434    7.878    8.722   A
+
+TOTAL tensor
+
+              -1.5287      0.8666     -2.3436
+               0.8666      2.2383      0.4849
+              -2.3436      0.4849      0.8271
+
+H        3 Eigenvalue  A_xx       2.2615      
+H        3 Eigenvector A_xx      -0.4682      0.2468      0.8485
+H        3 Eigenvalue  A_yy       2.4315      
+H        3 Eigenvector A_yy       0.2806      0.9520     -0.1221
+H        3 Eigenvalue  A_zz      -3.1562      
+H        3 Eigenvector A_zz      -0.8379      0.1809     -0.5150
+
+H        3 Iso:        0.5122 (MHz)
+============
+Atom: H        4
+============
+H        4 Coordinates      6.831    7.148    8.566   A
+
+TOTAL tensor
+
+               0.1283     -0.3269      0.7907
+              -0.3269      3.5750      0.1151
+               0.7907      0.1151      2.2669
+
+H        4 Eigenvalue  A_xx      -0.1645      
+H        4 Eigenvector A_xx       0.9456      0.0923     -0.3119
+H        4 Eigenvalue  A_yy       2.5274      
+H        4 Eigenvector A_yy       0.3138     -0.0064      0.9495
+H        4 Eigenvalue  A_zz       3.6071      
+H        4 Eigenvector A_zz      -0.0856      0.9957      0.0350
+
+H        4 Iso:        1.9900 (MHz)
+============
+Atom: H        5
+============
+H        5 Coordinates     10.368    7.305    8.941   A
+
+TOTAL tensor
+
+              48.1846      5.8821     -0.1789
+               5.8821     32.1071      5.8133
+              -0.1789      5.8133     18.2612
+
+H        5 Eigenvalue  A_xx      15.9885      
+H        5 Eigenvector A_xx       0.0712     -0.3613      0.9297
+H        5 Eigenvalue  A_yy      32.3695      
+H        5 Eigenvector A_yy      -0.3210      0.8742      0.3643
+H        5 Eigenvalue  A_zz      50.1949      
+H        5 Eigenvector A_zz      -0.9444     -0.3244     -0.0538
+
+H        5 Iso:       32.8510 (MHz)
+============
+Atom: H        6
+============
+H        6 Coordinates      8.621    5.348   12.349   A
+
+TOTAL tensor
+
+              37.0680     -7.6309     18.5392
+              -7.6309     39.0177     -0.3101
+              18.5392     -0.3101     54.0957
+
+H        6 Eigenvalue  A_xx      22.7133      
+H        6 Eigenvector A_xx      -0.8026     -0.3667      0.4705
+H        6 Eigenvalue  A_yy      40.7682      
+H        6 Eigenvector A_yy      -0.2237      0.9162      0.3325
+H        6 Eigenvalue  A_zz      66.6999      
+H        6 Eigenvector A_zz       0.5530     -0.1616      0.8174
+
+H        6 Iso:       43.3938 (MHz)
+============
+Atom: H        7
+============
+H        7 Coordinates     11.881    8.212   10.776   A
+
+TOTAL tensor
+
+            -176.4766     -3.1657     -1.7966
+              -3.1657   -180.2090      1.4371
+              -1.7966      1.4371   -175.3871
+
+H        7 Eigenvalue  A_xx    -172.7206      
+H        7 Eigenvector A_xx      -0.6468      0.3983      0.6504
+H        7 Eigenvalue  A_yy    -177.3132      
+H        7 Eigenvector A_yy       0.5934     -0.2729      0.7572
+H        7 Eigenvalue  A_zz    -182.0390      
+H        7 Eigenvector A_zz      -0.4791     -0.8757      0.0598
+
+H        7 Iso:     -177.3576 (MHz)
+============
+Atom: H        8
+============
+H        8 Coordinates     10.769    5.418   13.523   A
+
+TOTAL tensor
+
+             -24.7652     -3.2957     -0.8575
+              -3.2957    -14.4818      0.4539
+              -0.8575      0.4539    -14.5642
+
+H        8 Eigenvalue  A_xx     -13.1767      
+H        8 Eigenvector A_xx      -0.2751      0.8505      0.4483
+H        8 Eigenvalue  A_yy     -14.8604      
+H        8 Eigenvector A_yy       0.0715     -0.4469      0.8917
+H        8 Eigenvalue  A_zz     -25.7741      
+H        8 Eigenvector A_zz      -0.9588     -0.2773     -0.0621
+
+H        8 Iso:      -17.9370 (MHz)
+============
+Atom: H        9
+============
+H        9 Coordinates      4.013    8.087    0.783   A
+
+TOTAL tensor
+
+               0.6912     -0.2959     -0.0748
+              -0.2959     -1.7989     -0.2654
+              -0.0748     -0.2654      1.1629
+
+H        9 Eigenvalue  A_xx       0.7218      
+H        9 Eigenvector A_xx       0.9878     -0.1256      0.0920
+H        9 Eigenvalue  A_yy       1.1915      
+H        9 Eigenvector A_yy      -0.1023     -0.0779      0.9917
+H        9 Eigenvalue  A_zz      -1.8581      
+H        9 Eigenvector A_zz      -0.1174     -0.9890     -0.0898
+
+H        9 Iso:        0.0184 (MHz)
+============
+Atom: H       10
+============
+H       10 Coordinates      2.822    8.943   -0.198   A
+
+TOTAL tensor
+
+               0.7845     -0.0897     -0.0051
+              -0.0897     -1.6777     -0.1294
+              -0.0051     -0.1294      1.1205
+
+H       10 Eigenvalue  A_xx       0.7877      
+H       10 Eigenvector A_xx       0.9993     -0.0364      0.0012
+H       10 Eigenvalue  A_yy       1.1265      
+H       10 Eigenvector A_yy       0.0029      0.0460     -0.9989
+H       10 Eigenvalue  A_zz      -1.6869      
+H       10 Eigenvector A_zz       0.0363      0.9983      0.0461
+
+H       10 Iso:        0.0758 (MHz)
+============
+Atom: H       11
+============
+H       11 Coordinates      1.646    5.700    2.079   A
+
+TOTAL tensor
+
+              -0.2017      0.8222      0.9300
+               0.8222     -1.1469     -2.3528
+               0.9300     -2.3528      0.2198
+
+H       11 Eigenvalue  A_xx       0.2326      
+H       11 Eigenvector A_xx       0.9246      0.3649      0.1092
+H       11 Eigenvalue  A_yy       2.0190      
+H       11 Eigenvector A_yy       0.1290     -0.5697      0.8117
+H       11 Eigenvalue  A_zz      -3.3805      
+H       11 Eigenvector A_zz      -0.3584      0.7364      0.5738
+
+H       11 Iso:       -0.3763 (MHz)
+============
+Atom: H       12
+============
+H       12 Coordinates      3.279    6.350    2.236   A
+
+TOTAL tensor
+
+               0.9738     -0.1611     -0.1794
+              -0.1611     -2.0043     -1.9754
+              -0.1794     -1.9754     -0.1831
+
+H       12 Eigenvalue  A_xx       0.9542      
+H       12 Eigenvector A_xx       0.8918     -0.2839      0.3524
+H       12 Eigenvalue  A_yy       1.1138      
+H       12 Eigenvector A_yy      -0.4492     -0.4615      0.7650
+H       12 Eigenvalue  A_zz      -3.2816      
+H       12 Eigenvector A_zz       0.0545      0.8405      0.5390
+
+H       12 Iso:       -0.4045 (MHz)
+============
+Atom: H       13
+============
+H       13 Coordinates     -0.261    6.263    1.739   A
+
+TOTAL tensor
+
+              -0.0650      0.6881      0.3973
+               0.6881     -0.6626     -0.4681
+               0.3973     -0.4681      1.3060
+
+H       13 Eigenvalue  A_xx       0.3815      
+H       13 Eigenvector A_xx       0.8198      0.5690     -0.0642
+H       13 Eigenvalue  A_yy      -1.2589      
+H       13 Eigenvector A_yy      -0.5424      0.8076      0.2314
+H       13 Eigenvalue  A_zz       1.4558      
+H       13 Eigenvector A_zz       0.1836     -0.1549      0.9707
+
+H       13 Iso:        0.1928 (MHz)
+============
+Atom: H       14
+============
+H       14 Coordinates      1.626    8.256   -1.571   A
+
+TOTAL tensor
+
+               0.7315      0.0656     -0.0182
+               0.0656     -0.9690      0.3424
+              -0.0182      0.3424      0.8955
+
+H       14 Eigenvalue  A_xx       0.7339      
+H       14 Eigenvector A_xx       0.9988      0.0429      0.0218
+H       14 Eigenvalue  A_yy       0.9566      
+H       14 Eigenvector A_yy       0.0290     -0.1740     -0.9843
+H       14 Eigenvalue  A_zz      -1.0324      
+H       14 Eigenvector A_zz      -0.0384      0.9838     -0.1751
+
+H       14 Iso:        0.2194 (MHz)
+============
+Atom: H       15
+============
+H       15 Coordinates     -2.303    6.116    0.469   A
+
+TOTAL tensor
+
+              -1.7693     -1.6882     -0.1935
+              -1.6882      0.2889      0.2390
+              -0.1935      0.2390      2.2525
+
+H       15 Eigenvalue  A_xx       1.1534      
+H       15 Eigenvector A_xx      -0.4689      0.8423     -0.2658
+H       15 Eigenvalue  A_yy       2.3366      
+H       15 Eigenvector A_yy      -0.1387      0.2269      0.9640
+H       15 Eigenvalue  A_zz      -2.7179      
+H       15 Eigenvector A_zz      -0.8723     -0.4889     -0.0105
+
+H       15 Iso:        0.2574 (MHz)
+============
+Atom: H       16
+============
+H       16 Coordinates     -0.467    8.176   -2.802   A
+
+TOTAL tensor
+
+              -0.0515      0.1182     -0.0676
+               0.1182     -0.4210      0.2920
+              -0.0676      0.2920     -0.0165
+
+H       16 Eigenvalue  A_xx      -0.0184      
+H       16 Eigenvector A_xx       0.9708      0.2254     -0.0822
+H       16 Eigenvalue  A_yy       0.1366      
+H       16 Eigenvector A_yy      -0.0313      0.4585      0.8881
+H       16 Eigenvalue  A_zz      -0.6073      
+H       16 Eigenvector A_zz      -0.2378      0.8596     -0.4522
+
+H       16 Iso:       -0.1630 (MHz)
+============
+Atom: C        1
+============
+C        1 Coordinates      5.920    3.063    6.432   A
+
+TOTAL tensor
+
+              -0.1252      0.0274      0.0166
+               0.0274     -0.1049     -0.0495
+               0.0166     -0.0495     -0.3498
+
+C        1 Eigenvalue  A_xx      -0.0818      
+C        1 Eigenvector A_xx       0.4937      0.8601     -0.1284
+C        1 Eigenvalue  A_yy      -0.1367      
+C        1 Eigenvector A_yy      -0.8648      0.4701     -0.1766
+C        1 Eigenvalue  A_zz      -0.3615      
+C        1 Eigenvector A_zz      -0.0916      0.1983      0.9759
+
+C        1 Iso:       -0.1933 (MHz)
+============
+Atom: C        2
+============
+C        2 Coordinates      7.235    4.699    4.979   A
+
+TOTAL tensor
+
+               0.1926      0.0035      0.0178
+               0.0035      0.3438     -0.1382
+               0.0178     -0.1382     -0.0819
+
+C        2 Eigenvalue  A_xx      -0.1239      
+C        2 Eigenvector A_xx      -0.0570      0.2833      0.9573
+C        2 Eigenvalue  A_yy       0.1937      
+C        2 Eigenvector A_yy      -0.9983     -0.0247     -0.0522
+C        2 Eigenvalue  A_zz       0.3847      
+C        2 Eigenvector A_zz       0.0089     -0.9587      0.2842
+
+C        2 Iso:        0.1515 (MHz)
+============
+Atom: C        3
+============
+C        3 Coordinates      5.486    5.632    6.837   A
+
+TOTAL tensor
+
+               0.4967      0.0373      0.1213
+               0.0373      0.6652     -0.1400
+               0.1213     -0.1400      0.1968
+
+C        3 Eigenvalue  A_xx       0.1159      
+C        3 Eigenvector A_xx      -0.3161      0.2544      0.9140
+C        3 Eigenvalue  A_yy       0.5390      
+C        3 Eigenvector A_yy      -0.9485     -0.0639     -0.3103
+C        3 Eigenvalue  A_zz       0.7039      
+C        3 Eigenvector A_zz      -0.0205     -0.9650      0.2615
+
+C        3 Iso:        0.4529 (MHz)
+============
+Atom: C        4
+============
+C        4 Coordinates      7.259    5.080   10.053   A
+
+TOTAL tensor
+
+               3.0962      0.2264     -0.3510
+               0.2264      3.9956     -0.2338
+              -0.3510     -0.2338      3.6330
+
+C        4 Eigenvalue  A_xx       2.9126      
+C        4 Eigenvector A_xx       0.9069     -0.1013      0.4090
+C        4 Eigenvalue  A_yy       3.5823      
+C        4 Eigenvector A_yy      -0.2786      0.5840      0.7625
+C        4 Eigenvalue  A_zz       4.2300      
+C        4 Eigenvector A_zz      -0.3161     -0.8054      0.5014
+
+C        4 Iso:        3.5749 (MHz)
+============
+Atom: C        5
+============
+C        5 Coordinates      7.891    6.938    8.701   A
+
+TOTAL tensor
+
+              -3.2841     -0.0391     -0.2406
+              -0.0391     -2.2571     -0.1091
+              -0.2406     -0.1091     -2.3340
+
+C        5 Eigenvalue  A_xx      -2.1673      
+C        5 Eigenvector A_xx      -0.1150     -0.7467      0.6551
+C        5 Eigenvalue  A_yy      -2.3625      
+C        5 Eigenvector A_yy      -0.2154      0.6626      0.7174
+C        5 Eigenvalue  A_zz      -3.3453      
+C        5 Eigenvector A_zz      -0.9697     -0.0586     -0.2370
+
+C        5 Iso:       -2.6250 (MHz)
+============
+Atom: C        6
+============
+C        6 Coordinates      8.913    2.271    7.057   A
+
+TOTAL tensor
+
+               0.3187     -0.0287     -0.0220
+              -0.0287      0.1980     -0.0258
+              -0.0220     -0.0258      0.1068
+
+C        6 Eigenvalue  A_xx       0.0962      
+C        6 Eigenvector A_xx       0.1302      0.2784      0.9516
+C        6 Eigenvalue  A_yy       0.2009      
+C        6 Eigenvector A_yy       0.1731      0.9387     -0.2983
+C        6 Eigenvalue  A_zz       0.3263      
+C        6 Eigenvector A_zz      -0.9763      0.2036      0.0740
+
+C        6 Iso:        0.2078 (MHz)
+============
+Atom: C        7
+============
+C        7 Coordinates     10.494    3.863    8.603   A
+
+TOTAL tensor
+
+               0.3019     -0.0640     -0.0114
+              -0.0640     -0.2256     -0.3802
+              -0.0114     -0.3802     -0.0496
+
+C        7 Eigenvalue  A_xx       0.2385      
+C        7 Eigenvector A_xx      -0.4154     -0.5415      0.7309
+C        7 Eigenvalue  A_yy       0.3199      
+C        7 Eigenvector A_yy       0.9071     -0.3071      0.2880
+C        7 Eigenvalue  A_zz      -0.5318      
+C        7 Eigenvector A_zz       0.0685      0.7826      0.6187
+
+C        7 Iso:        0.0089 (MHz)
+============
+Atom: C        8
+============
+C        8 Coordinates     10.153    4.210    6.014   A
+
+TOTAL tensor
+
+              -0.0442     -0.0204     -0.0206
+              -0.0204     -0.0282     -0.1361
+              -0.0206     -0.1361     -0.4742
+
+C        8 Eigenvalue  A_xx       0.0135      
+C        8 Eigenvector A_xx      -0.2409      0.9374     -0.2515
+C        8 Eigenvalue  A_yy      -0.0463      
+C        8 Eigenvector A_yy       0.9690      0.2179     -0.1160
+C        8 Eigenvalue  A_zz      -0.5139      
+C        8 Eigenvector A_zz       0.0539      0.2716      0.9609
+
+C        8 Iso:       -0.1822 (MHz)
+============
+Atom: C        9
+============
+C        9 Coordinates      9.350    6.292   10.532   A
+
+TOTAL tensor
+
+              77.1963     -1.6633      1.6210
+              -1.6633     77.8376      2.8942
+               1.6210      2.8942     74.8254
+
+C        9 Eigenvalue  A_xx      72.0731      
+C        9 Eigenvector A_xx      -0.4047     -0.5009      0.7651
+C        9 Eigenvalue  A_yy      78.0075      
+C        9 Eigenvector A_yy       0.8634      0.0663      0.5001
+C        9 Eigenvalue  A_zz      79.7787      
+C        9 Eigenvector A_zz      -0.3012      0.8630      0.4057
+
+C        9 Iso:       76.6197 (MHz)
+============
+Atom: C       10
+============
+C       10 Coordinates     10.412    6.923    9.948   A
+
+TOTAL tensor
+
+            -119.6037      1.7597     -0.2597
+               1.7597   -122.2519     -0.9921
+              -0.2597     -0.9921   -121.1428
+
+C       10 Eigenvalue  A_xx    -118.5410      
+C       10 Eigenvector A_xx       0.8425      0.4699     -0.2633
+C       10 Eigenvalue  A_yy    -121.0522      
+C       10 Eigenvector A_yy      -0.3850      0.1834     -0.9045
+C       10 Eigenvalue  A_zz    -123.4052      
+C       10 Eigenvector A_zz      -0.3768      0.8634      0.3354
+
+C       10 Iso:     -120.9995 (MHz)
+============
+Atom: C       11
+============
+C       11 Coordinates      9.474    5.767   11.844   A
+
+TOTAL tensor
+
+            -155.5642      0.4367      1.8289
+               0.4367   -159.2436     -1.8365
+               1.8289     -1.8365   -154.6076
+
+C       11 Eigenvalue  A_xx    -152.9508      
+C       11 Eigenvector A_xx       0.5388     -0.2013      0.8180
+C       11 Eigenvalue  A_yy    -156.3345      
+C       11 Eigenvector A_yy      -0.8086     -0.3961      0.4351
+C       11 Eigenvalue  A_zz    -160.1301      
+C       11 Eigenvector A_zz       0.2364     -0.8959     -0.3762
+
+C       11 Iso:     -156.4718 (MHz)
+============
+Atom: C       12
+============
+C       12 Coordinates     11.702    7.131   10.656   A
+
+TOTAL tensor
+
+              39.9376     -0.2950     -0.6337
+              -0.2950     40.1659      0.5044
+              -0.6337      0.5044     39.5708
+
+C       12 Eigenvalue  A_xx      39.0387      
+C       12 Eigenvector A_xx       0.5061     -0.2385      0.8289
+C       12 Eigenvalue  A_yy      39.7812      
+C       12 Eigenvector A_yy      -0.6488     -0.7385      0.1837
+C       12 Eigenvalue  A_zz      40.8544      
+C       12 Eigenvector A_zz       0.5683     -0.6307     -0.5284
+
+C       12 Iso:       39.8914 (MHz)
+============
+Atom: C       13
+============
+C       13 Coordinates     10.693    5.837   12.532   A
+
+TOTAL tensor
+
+              75.1826     -2.6161     -0.5468
+              -2.6161     82.1351      0.8947
+              -0.5468      0.8947     81.4282
+
+C       13 Eigenvalue  A_xx      74.3003      
+C       13 Eigenvector A_xx       0.9491      0.3131      0.0335
+C       13 Eigenvalue  A_yy      80.9335      
+C       13 Eigenvector A_yy      -0.1098      0.4287     -0.8967
+C       13 Eigenvalue  A_zz      83.5120      
+C       13 Eigenvector A_zz      -0.2951      0.8474      0.4413
+
+C       13 Iso:       79.5819 (MHz)
+============
+Atom: C       14
+============
+C       14 Coordinates     11.762    6.459   11.972   A
+
+TOTAL tensor
+
+            -149.6529      1.2462     -0.9455
+               1.2462   -150.6482     -1.3124
+              -0.9455     -1.3124   -149.8365
+
+C       14 Eigenvalue  A_xx    -147.6909      
+C       14 Eigenvector A_xx       0.6159      0.5216     -0.5905
+C       14 Eigenvalue  A_yy    -150.6840      
+C       14 Eigenvector A_yy       0.7240     -0.0791      0.6853
+C       14 Eigenvalue  A_zz    -151.7626      
+C       14 Eigenvector A_zz      -0.3108      0.8495      0.4263
+
+C       14 Iso:     -150.0458 (MHz)
+============
+Atom: C       15
+============
+C       15 Coordinates      4.286   10.494    4.313   A
+
+TOTAL tensor
+
+              -0.2651      0.0039     -0.0250
+               0.0039     -0.4089      0.1376
+              -0.0250      0.1376     -0.4424
+
+C       15 Eigenvalue  A_xx      -0.2573      
+C       15 Eigenvector A_xx       0.9067     -0.2707     -0.3235
+C       15 Eigenvalue  A_yy      -0.2933      
+C       15 Eigenvector A_yy       0.4159      0.7020      0.5781
+C       15 Eigenvalue  A_zz      -0.5658      
+C       15 Eigenvector A_zz       0.0706     -0.6587      0.7491
+
+C       15 Iso:       -0.3721 (MHz)
+============
+Atom: C       16
+============
+C       16 Coordinates      2.976    8.875    5.807   A
+
+TOTAL tensor
+
+               0.2032      0.0004     -0.0026
+               0.0004      0.1038      0.1009
+              -0.0026      0.1009     -0.1276
+
+C       16 Eigenvalue  A_xx       0.1416      
+C       16 Eigenvector A_xx       0.0088      0.9364      0.3508
+C       16 Eigenvalue  A_yy      -0.1654      
+C       16 Eigenvector A_yy       0.0069     -0.3509      0.9364
+C       16 Eigenvalue  A_zz       0.2032      
+C       16 Eigenvector A_zz      -0.9999      0.0058      0.0095
+
+C       16 Iso:        0.0598 (MHz)
+============
+Atom: C       17
+============
+C       17 Coordinates      4.707    7.896    3.921   A
+
+TOTAL tensor
+
+               0.1059     -0.0065     -0.0137
+              -0.0065     -0.0518     -0.0614
+              -0.0137     -0.0614     -0.0314
+
+C       17 Eigenvalue  A_xx       0.0201      
+C       17 Eigenvector A_xx       0.0712     -0.6510      0.7557
+C       17 Eigenvalue  A_yy      -0.1047      
+C       17 Eigenvector A_yy       0.0657      0.7591      0.6477
+C       17 Eigenvalue  A_zz       0.1073      
+C       17 Eigenvector A_zz      -0.9953      0.0035      0.0968
+
+C       17 Iso:        0.0075 (MHz)
+============
+Atom: C       18
+============
+C       18 Coordinates      2.978    8.428    0.741   A
+
+TOTAL tensor
+
+               0.1648     -0.0137     -0.0061
+              -0.0137     -0.5064     -0.0559
+              -0.0061     -0.0559      0.2446
+
+C       18 Eigenvalue  A_xx       0.1648      
+C       18 Eigenvector A_xx       0.9980     -0.0252      0.0581
+C       18 Eigenvalue  A_yy       0.2491      
+C       18 Eigenvector A_yy      -0.0598     -0.0726      0.9956
+C       18 Eigenvalue  A_zz      -0.5109      
+C       18 Eigenvector A_zz      -0.0209     -0.9970     -0.0739
+
+C       18 Iso:       -0.0323 (MHz)
+============
+Atom: C       19
+============
+C       19 Coordinates      2.231    6.614    2.097   A
+
+TOTAL tensor
+
+               0.8146      0.1177      0.0721
+               0.1177      0.2537     -0.3709
+               0.0721     -0.3709      0.7318
+
+C       19 Eigenvalue  A_xx       0.0273      
+C       19 Eigenvector A_xx      -0.1725      0.8642      0.4727
+C       19 Eigenvalue  A_yy       0.8383      
+C       19 Eigenvector A_yy      -0.9825     -0.1853     -0.0197
+C       19 Eigenvalue  A_zz       0.9346      
+C       19 Eigenvector A_zz       0.0706     -0.4678      0.8810
+
+C       19 Iso:        0.6001 (MHz)
+============
+Atom: C       20
+============
+C       20 Coordinates      1.310   11.319    3.713   A
+
+TOTAL tensor
+
+               0.0958     -0.0377      0.0855
+              -0.0377      0.0124      0.2314
+               0.0855      0.2314     -0.0676
+
+C       20 Eigenvalue  A_xx       0.1103      
+C       20 Eigenvector A_xx      -0.9402      0.3406     -0.0091
+C       20 Eigenvalue  A_yy       0.2141      
+C       20 Eigenvector A_yy      -0.2506     -0.7093     -0.6589
+C       20 Eigenvalue  A_zz      -0.2837      
+C       20 Eigenvector A_zz      -0.2308     -0.6172      0.7522
+
+C       20 Iso:        0.0136 (MHz)
+============
+Atom: C       21
+============
+C       21 Coordinates     -0.245    9.735    2.143   A
+
+TOTAL tensor
+
+              -0.0425     -0.0039      0.0071
+              -0.0039     -0.2662      0.0598
+               0.0071      0.0598      0.1108
+
+C       21 Eigenvalue  A_xx      -0.0427      
+C       21 Eigenvector A_xx       0.9990     -0.0270     -0.0359
+C       21 Eigenvalue  A_yy       0.1203      
+C       21 Eigenvector A_yy      -0.0396     -0.1525     -0.9875
+C       21 Eigenvalue  A_zz      -0.2756      
+C       21 Eigenvector A_zz       0.0212      0.9879     -0.1534
+
+C       21 Iso:       -0.0660 (MHz)
+============
+Atom: C       22
+============
+C       22 Coordinates      0.055    9.395    4.760   A
+
+TOTAL tensor
+
+               0.0973      0.0028      0.0014
+               0.0028      0.0154      0.0643
+               0.0014      0.0643     -0.0219
+
+C       22 Eigenvalue  A_xx       0.0634      
+C       22 Eigenvector A_xx      -0.0898      0.7963      0.5982
+C       22 Eigenvalue  A_yy      -0.0702      
+C       22 Eigenvector A_yy       0.0033     -0.6004      0.7997
+C       22 Eigenvalue  A_zz       0.0976      
+C       22 Eigenvector A_zz      -0.9960     -0.0738     -0.0513
+
+C       22 Iso:        0.0303 (MHz)
+============
+Atom: C       23
+============
+C       23 Coordinates      0.856    7.302    0.201   A
+
+TOTAL tensor
+
+               0.4415      0.1881      0.0332
+               0.1881     -0.0110     -0.0359
+               0.0332     -0.0359      0.7081
+
+C       23 Eigenvalue  A_xx      -0.0816      
+C       23 Eigenvector A_xx      -0.3411      0.9383      0.0570
+C       23 Eigenvalue  A_yy       0.5077      
+C       23 Eigenvector A_yy       0.9339      0.3451     -0.0931
+C       23 Eigenvalue  A_zz       0.7124      
+C       23 Eigenvector A_zz       0.1070     -0.0215      0.9940
+
+C       23 Iso:        0.3795 (MHz)
+============
+Atom: C       24
+============
+C       24 Coordinates     -0.272    6.684    0.746   A
+
+TOTAL tensor
+
+              -1.0838      0.1803      0.0713
+               0.1803     -1.1697     -0.0359
+               0.0713     -0.0359     -0.6488
+
+C       24 Eigenvalue  A_xx      -0.6373      
+C       24 Eigenvector A_xx       0.1517     -0.0154      0.9883
+C       24 Eigenvalue  A_yy      -0.9451      
+C       24 Eigenvector A_yy      -0.7668     -0.6328      0.1079
+C       24 Eigenvalue  A_zz      -1.3199      
+C       24 Eigenvector A_zz       0.6237     -0.7742     -0.1078
+
+C       24 Iso:       -0.9674 (MHz)
+============
+Atom: C       25
+============
+C       25 Coordinates      0.762    7.829   -1.090   A
+
+TOTAL tensor
+
+              -0.8810      0.1166     -0.0166
+               0.1166     -1.2842      0.0740
+              -0.0166      0.0740     -0.7319
+
+C       25 Eigenvalue  A_xx      -0.7222      
+C       25 Eigenvector A_xx      -0.0091      0.1287      0.9916
+C       25 Eigenvalue  A_yy      -0.8497      
+C       25 Eigenvector A_yy      -0.9666     -0.2553      0.0242
+C       25 Eigenvalue  A_zz      -1.3251      
+C       25 Eigenvector A_zz       0.2563     -0.9583      0.1267
+
+C       25 Iso:       -0.9657 (MHz)
+============
+Atom: C       26
+============
+C       26 Coordinates     -1.454    6.615    0.029   A
+
+TOTAL tensor
+
+              -1.4070     -0.0569     -0.0042
+              -0.0569     -1.2250      0.0756
+              -0.0042      0.0756     -0.8464
+
+C       26 Eigenvalue  A_xx      -0.8314      
+C       26 Eigenvector A_xx      -0.0262      0.1923      0.9810
+C       26 Eigenvalue  A_yy      -1.2232      
+C       26 Eigenvector A_yy      -0.2860      0.9389     -0.1917
+C       26 Eigenvalue  A_zz      -1.4239      
+C       26 Eigenvector A_zz      -0.9579     -0.2856      0.0304
+
+C       26 Iso:       -1.1595 (MHz)
+============
+Atom: C       27
+============
+C       27 Coordinates     -0.421    7.776   -1.802   A
+
+TOTAL tensor
+
+               0.4962      0.0545     -0.0280
+               0.0545      0.4078      0.0954
+              -0.0280      0.0954      0.6561
+
+C       27 Eigenvalue  A_xx       0.3502      
+C       27 Eigenvector A_xx      -0.3841      0.8709     -0.3067
+C       27 Eigenvalue  A_yy       0.5210      
+C       27 Eigenvector A_yy       0.9220      0.3796     -0.0767
+C       27 Eigenvalue  A_zz       0.6890      
+C       27 Eigenvector A_zz      -0.0496      0.3123      0.9487
+
+C       27 Iso:        0.5200 (MHz)
+============
+Atom: C       28
+============
+C       28 Coordinates     -1.529    7.175   -1.233   A
+
+TOTAL tensor
+
+              -0.8929     -0.0220      0.0166
+              -0.0220     -0.9027      0.1044
+               0.0166      0.1044     -0.6107
+
+C       28 Eigenvalue  A_xx      -0.5770      
+C       28 Eigenvector A_xx       0.0289      0.3034      0.9524
+C       28 Eigenvalue  A_yy      -0.8809      
+C       28 Eigenvector A_yy      -0.9044      0.4138     -0.1043
+C       28 Eigenvalue  A_zz      -0.9484      
+C       28 Eigenvector A_zz      -0.4258     -0.8583      0.2864
+
+C       28 Iso:       -0.8021 (MHz)
+============
+Atom: N        1
+============
+N        1 Coordinates      8.099    6.215    9.898   A
+
+TOTAL tensor
+
+              -5.0371     -0.2005     -0.3042
+              -0.2005     -5.2092      0.1773
+              -0.3042      0.1773     -4.9851
+
+N        1 Eigenvalue  A_xx      -4.5910      
+N        1 Eigenvector A_xx      -0.6321      0.3961      0.6660
+N        1 Eigenvalue  A_yy      -5.2944      
+N        1 Eigenvector A_yy       0.3735     -0.5974      0.7097
+N        1 Eigenvalue  A_zz      -5.3460      
+N        1 Eigenvector A_zz      -0.6789     -0.6973     -0.2297
+
+N        1 Iso:       -5.0771 (MHz)
+============
+Atom: N        2
+============
+N        2 Coordinates      2.075    7.339    0.890   A
+
+TOTAL tensor
+
+               0.2824     -0.0261     -0.0034
+              -0.0261      0.5657      0.0605
+              -0.0034      0.0605      0.2458
+
+N        2 Eigenvalue  A_xx       0.2347      
+N        2 Eigenvector A_xx      -0.0303     -0.1819      0.9828
+N        2 Eigenvalue  A_yy       0.2801      
+N        2 Eigenvector A_yy       0.9956      0.0813      0.0458
+N        2 Eigenvalue  A_zz       0.5791      
+N        2 Eigenvector A_zz      -0.0882      0.9799      0.1787
+
+N        2 Iso:        0.3646 (MHz)
+============
+Atom: O        1
+============
+O        1 Coordinates      5.289    2.119    6.291   A
+
+TOTAL tensor
+
+              -0.0115     -0.0099     -0.0131
+              -0.0099      0.0008     -0.0124
+              -0.0131     -0.0124      0.0984
+
+O        1 Eigenvalue  A_xx       0.0061      
+O        1 Eigenvector A_xx       0.5114     -0.8583     -0.0427
+O        1 Eigenvalue  A_yy      -0.0196      
+O        1 Eigenvector A_yy       0.8530      0.5009      0.1469
+O        1 Eigenvalue  A_zz       0.1012      
+O        1 Eigenvector A_zz      -0.1048     -0.1115      0.9882
+
+O        1 Iso:        0.0292 (MHz)
+============
+Atom: O        2
+============
+O        2 Coordinates      7.513    4.785    3.873   A
+
+TOTAL tensor
+
+               1.0302     -0.0280     -0.0323
+              -0.0280      0.9732      0.1417
+              -0.0323      0.1417      1.1926
+
+O        2 Eigenvalue  A_xx       0.9027      
+O        2 Eigenvector A_xx       0.0883      0.8988     -0.4295
+O        2 Eigenvalue  A_yy       1.0240      
+O        2 Eigenvector A_yy       0.9814     -0.0046      0.1920
+O        2 Eigenvalue  A_zz       1.2693      
+O        2 Eigenvector A_zz      -0.1706      0.4384      0.8824
+
+O        2 Iso:        1.0653 (MHz)
+============
+Atom: O        3
+============
+O        3 Coordinates      4.620    6.380    6.917   A
+
+TOTAL tensor
+
+              -0.0993     -0.0160     -0.0891
+              -0.0160     -0.1881      0.0375
+              -0.0891      0.0375      0.1978
+
+O        3 Eigenvalue  A_xx      -0.1235      
+O        3 Eigenvector A_xx      -0.9584      0.0774     -0.2747
+O        3 Eigenvalue  A_yy      -0.1924      
+O        3 Eigenvector A_yy       0.1009      0.9923     -0.0724
+O        3 Eigenvalue  A_zz       0.2264      
+O        3 Eigenvector A_zz      -0.2669      0.0971      0.9588
+
+O        3 Iso:       -0.0298 (MHz)
+============
+Atom: O        4
+============
+O        4 Coordinates      8.685    1.180    6.790   A
+
+TOTAL tensor
+
+              -0.0106      0.0088      0.0005
+               0.0088      0.0622     -0.0347
+               0.0005     -0.0347      0.0910
+
+O        4 Eigenvalue  A_xx      -0.0118      
+O        4 Eigenvector A_xx       0.9885     -0.1416     -0.0529
+O        4 Eigenvalue  A_yy       0.0402      
+O        4 Eigenvector A_yy       0.1469      0.8176      0.5567
+O        4 Eigenvalue  A_zz       0.1144      
+O        4 Eigenvector A_zz      -0.0356     -0.5581      0.8290
+
+O        4 Iso:        0.0476 (MHz)
+============
+Atom: O        5
+============
+O        5 Coordinates     11.388    3.714    9.306   A
+
+TOTAL tensor
+
+               0.5562     -0.1048     -0.0724
+              -0.1048      0.7064      0.1958
+              -0.0724      0.1958      0.6730
+
+O        5 Eigenvalue  A_xx       0.4838      
+O        5 Eigenvector A_xx      -0.4662     -0.6978      0.5438
+O        5 Eigenvalue  A_yy       0.5228      
+O        5 Eigenvector A_yy       0.8243     -0.1196      0.5533
+O        5 Eigenvalue  A_zz       0.9289      
+O        5 Eigenvector A_zz      -0.3211      0.7062      0.6310
+
+O        5 Iso:        0.6452 (MHz)
+============
+Atom: O        6
+============
+O        6 Coordinates     10.786    4.373    5.077   A
+
+TOTAL tensor
+
+              -0.2153      0.0035     -0.0098
+               0.0035     -0.2500      0.0629
+              -0.0098      0.0629      0.0649
+
+O        6 Eigenvalue  A_xx       0.0773      
+O        6 Eigenvector A_xx      -0.0307      0.1882      0.9816
+O        6 Eigenvalue  A_yy      -0.2150      
+O        6 Eigenvector A_yy      -0.9933     -0.1151     -0.0090
+O        6 Eigenvalue  A_zz      -0.2627      
+O        6 Eigenvector A_zz       0.1113     -0.9754      0.1905
+
+O        6 Iso:       -0.1335 (MHz)
+============
+Atom: O        7
+============
+O        7 Coordinates      4.899   11.455    4.413   A
+
+TOTAL tensor
+
+               0.0021     -0.0005      0.0093
+              -0.0005      0.0380     -0.0934
+               0.0093     -0.0934      0.1150
+
+O        7 Eigenvalue  A_xx       0.0026      
+O        7 Eigenvector A_xx       0.9839      0.1685      0.0588
+O        7 Eigenvalue  A_yy      -0.0253      
+O        7 Eigenvector A_yy      -0.1726      0.8147      0.5536
+O        7 Eigenvalue  A_zz       0.1778      
+O        7 Eigenvector A_zz       0.0454     -0.5548      0.8307
+
+O        7 Iso:        0.0517 (MHz)
+============
+Atom: O        8
+============
+O        8 Coordinates      2.691    8.818    6.914   A
+
+TOTAL tensor
+
+              -0.3909     -0.0085      0.0184
+              -0.0085     -0.3229     -0.1248
+               0.0184     -0.1248     -0.1385
+
+O        8 Eigenvalue  A_xx      -0.0742      
+O        8 Eigenvector A_xx       0.0638     -0.4494      0.8910
+O        8 Eigenvalue  A_yy      -0.3858      
+O        8 Eigenvector A_yy       0.1087      0.8907      0.4414
+O        8 Eigenvalue  A_zz      -0.3922      
+O        8 Eigenvector A_zz      -0.9920      0.0687      0.1057
+
+O        8 Iso:       -0.2841 (MHz)
+============
+Atom: O        9
+============
+O        9 Coordinates      5.557    7.134    3.810   A
+
+TOTAL tensor
+
+               0.3409      0.0093      0.0148
+               0.0093      0.3797      0.0678
+               0.0148      0.0678      0.4004
+
+O        9 Eigenvalue  A_xx       0.3211      
+O        9 Eigenvector A_xx       0.1437      0.7389     -0.6584
+O        9 Eigenvalue  A_yy       0.3388      
+O        9 Eigenvector A_yy       0.9794     -0.2017     -0.0126
+O        9 Eigenvalue  A_zz       0.4610      
+O        9 Eigenvector A_zz       0.1421      0.6430      0.7526
+
+O        9 Iso:        0.3736 (MHz)
+============
+Atom: O       10
+============
+O       10 Coordinates      1.516   12.413    3.990   A
+
+TOTAL tensor
+
+              -0.1207      0.0238     -0.0705
+               0.0238     -0.1508     -0.1306
+              -0.0705     -0.1306      0.0961
+
+O       10 Eigenvalue  A_xx      -0.1391      
+O       10 Eigenvector A_xx      -0.9655      0.1760     -0.1918
+O       10 Eigenvalue  A_yy       0.1712      
+O       10 Eigenvector A_yy      -0.2464     -0.3798      0.8917
+O       10 Eigenvalue  A_zz      -0.2076      
+O       10 Eigenvector A_zz      -0.0841     -0.9082     -0.4100
+
+O       10 Iso:       -0.0585 (MHz)
+============
+Atom: O       11
+============
+O       11 Coordinates     -1.103    9.886    1.401   A
+
+TOTAL tensor
+
+              -0.0295     -0.0224      0.0106
+              -0.0224      0.1198     -0.0273
+               0.0106     -0.0273     -0.1570
+
+O       11 Eigenvalue  A_xx      -0.0325      
+O       11 Eigenvector A_xx       0.9868      0.1543      0.0502
+O       11 Eigenvalue  A_yy       0.1260      
+O       11 Eigenvector A_yy      -0.1487      0.9838     -0.1004
+O       11 Eigenvalue  A_zz      -0.1602      
+O       11 Eigenvector A_zz      -0.0649      0.0916      0.9937
+
+O       11 Iso:       -0.0222 (MHz)
+============
+Atom: O       12
+============
+O       12 Coordinates     -0.578    9.236    5.700   A
+
+TOTAL tensor
+
+               0.0107     -0.0014     -0.0002
+              -0.0014      0.0225     -0.0374
+              -0.0002     -0.0374      0.0853
+
+O       12 Eigenvalue  A_xx       0.0048      
+O       12 Eigenvector A_xx       0.2175      0.8851      0.4113
+O       12 Eigenvalue  A_yy       0.0110      
+O       12 Eigenvector A_yy       0.9760     -0.1952     -0.0962
+O       12 Eigenvalue  A_zz       0.1027      
+O       12 Eigenvector A_zz       0.0048     -0.4224      0.9064
+
+O       12 Iso:        0.0395 (MHz)
+============
+Atom: S        1
+============
+S        1 Coordinates      7.339    3.757    8.751   A
+
+TOTAL tensor
+
+               1.5026      0.3165      0.2531
+               0.3165      0.1600     -0.7918
+               0.2531     -0.7918      1.2803
+
+S        1 Eigenvalue  A_xx      -0.3358      
+S        1 Eigenvector A_xx       0.2117     -0.8642     -0.4565
+S        1 Eigenvalue  A_yy       1.5466      
+S        1 Eigenvector A_yy       0.8591      0.3872     -0.3347
+S        1 Eigenvalue  A_zz       1.7321      
+S        1 Eigenvector A_zz       0.4660     -0.3214      0.8244
+
+S        1 Iso:        0.9810 (MHz)
+============
+Atom: S        2
+============
+S        2 Coordinates      8.431    6.089    7.131   A
+
+TOTAL tensor
+
+              -1.0413      0.1818      0.5245
+               0.1818     -0.9113     -0.5416
+               0.5245     -0.5416     -1.2160
+
+S        2 Eigenvalue  A_xx      -0.4244      
+S        2 Eigenvector A_xx      -0.4011      0.6102     -0.6832
+S        2 Eigenvalue  A_yy      -0.8016      
+S        2 Eigenvector A_yy       0.7589      0.6391      0.1252
+S        2 Eigenvalue  A_zz      -1.9426      
+S        2 Eigenvector A_zz      -0.5131      0.4682      0.7194
+
+S        2 Iso:       -1.0562 (MHz)
+============
+Atom: S        3
+============
+S        3 Coordinates      2.893    9.777    2.019   A
+
+TOTAL tensor
+
+              -3.2755      0.0311     -0.0115
+               0.0311     -3.2718     -0.0292
+              -0.0115     -0.0292     -3.3051
+
+S        3 Eigenvalue  A_xx      -3.2308      
+S        3 Eigenvector A_xx      -0.5927     -0.7143      0.3721
+S        3 Eigenvalue  A_yy      -3.2986      
+S        3 Eigenvector A_yy       0.7865     -0.4137      0.4585
+S        3 Eigenvalue  A_zz      -3.3231      
+S        3 Eigenvector A_zz       0.1736     -0.5645     -0.8070
+
+S        3 Iso:       -3.2841 (MHz)
+============
+Atom: S        4
+============
+S        4 Coordinates      1.744    7.492    3.663   A
+
+TOTAL tensor
+
+              -0.1829     -0.0134      0.0013
+              -0.0134     -0.2038     -0.0296
+               0.0013     -0.0296     -0.1755
+
+S        4 Eigenvalue  A_xx      -0.1544      
+S        4 Eigenvector A_xx       0.2912     -0.5478      0.7843
+S        4 Eigenvalue  A_yy      -0.1827      
+S        4 Eigenvector A_yy      -0.9237      0.0524      0.3795
+S        4 Eigenvalue  A_zz      -0.2252      
+S        4 Eigenvector A_zz      -0.2490     -0.8350     -0.4907
+
+S        4 Iso:       -0.1874 (MHz)
+============
+Atom: Fe       1
+============
+Fe       1 Coordinates      6.849    4.539    6.690   A
+
+TOTAL tensor
+
+              -0.0150      0.1422     -0.0035
+               0.1422      0.1329     -0.1065
+              -0.0035     -0.1065      0.0085
+
+Fe       1 Eigenvalue  A_xx      -0.0026      
+Fe       1 Eigenvector A_xx       0.5554      0.0685      0.8288
+Fe       1 Eigenvalue  A_yy      -0.1263      
+Fe       1 Eigenvector A_yy      -0.7071      0.5635      0.4272
+Fe       1 Eigenvalue  A_zz       0.2553      
+Fe       1 Eigenvector A_zz      -0.4378     -0.8233      0.3614
+
+Fe       1 Iso:        0.0421 (MHz)
+============
+Atom: Fe       2
+============
+Fe       2 Coordinates      9.159    3.960    7.444   A
+
+TOTAL tensor
+
+               0.0212     -0.0297      0.0800
+              -0.0297     -0.1931     -0.0195
+               0.0800     -0.0195     -0.1375
+
+Fe       2 Eigenvalue  A_xx       0.0593      
+Fe       2 Eigenvector A_xx       0.9129     -0.1370      0.3846
+Fe       2 Eigenvalue  A_yy      -0.1694      
+Fe       2 Eigenvector A_yy      -0.4066     -0.2204      0.8866
+Fe       2 Eigenvalue  A_zz      -0.1994      
+Fe       2 Eigenvector A_zz       0.0367      0.9657      0.2569
+
+Fe       2 Iso:       -0.1031 (MHz)
+============
+Atom: Fe       3
+============
+Fe       3 Coordinates      3.359    9.010    4.089   A
+
+TOTAL tensor
+
+              -0.1617      0.0267      0.0153
+               0.0267     -0.1229     -0.0159
+               0.0153     -0.0159     -0.1314
+
+Fe       3 Eigenvalue  A_xx      -0.1065      
+Fe       3 Eigenvector A_xx       0.3239      0.8753     -0.3591
+Fe       3 Eigenvalue  A_yy      -0.1258      
+Fe       3 Eigenvector A_yy      -0.4905     -0.1692     -0.8548
+Fe       3 Eigenvalue  A_zz      -0.1838      
+Fe       3 Eigenvector A_zz      -0.8090      0.4530      0.3746
+
+Fe       3 Iso:       -0.1387 (MHz)
+============
+Atom: Fe       4
+============
+Fe       4 Coordinates      1.062    9.627    3.330   A
+
+TOTAL tensor
+
+               0.0437     -0.0047      0.0070
+              -0.0047      0.0362      0.0138
+               0.0070      0.0138      0.0381
+
+Fe       4 Eigenvalue  A_xx       0.0204      
+Fe       4 Eigenvector A_xx       0.3345      0.6749     -0.6577
+Fe       4 Eigenvalue  A_yy       0.0459      
+Fe       4 Eigenvector A_yy      -0.8858      0.4634      0.0251
+Fe       4 Eigenvalue  A_zz       0.0517      
+Fe       4 Eigenvector A_zz       0.3217      0.5742      0.7528
+
+Fe       4 Iso:        0.0393 (MHz)
+============
+Atom: Br       1
+============
+Br       1 Coordinates     13.394    6.604   12.923   A
+
+TOTAL tensor
+
+             -98.3203    -29.9731    -33.1757
+             -29.9731     -3.8466     30.5673
+             -33.1757     30.5673    -67.6111
+
+Br       1 Eigenvalue  A_xx      22.2616      
+Br       1 Eigenvector A_xx       0.3246     -0.8525     -0.4098
+Br       1 Eigenvalue  A_yy     -71.6833      
+Br       1 Eigenvector A_yy      -0.3794     -0.5142      0.7692
+Br       1 Eigenvalue  A_zz    -120.3562      
+Br       1 Eigenvector A_zz       0.8664      0.0942      0.4903
+
+Br       1 Iso:      -56.5927 (MHz)
+============
+Atom: Br       2
+============
+Br       2 Coordinates     -3.153    7.078   -2.218   A
+
+TOTAL tensor
+
+              -0.5000      0.1357     -1.5704
+               0.1357     -2.5607      0.1923
+              -1.5704      0.1923     -1.9484
+
+Br       2 Eigenvalue  A_xx       0.5052      
+Br       2 Eigenvector A_xx      -0.8424     -0.0035      0.5389
+Br       2 Eigenvalue  A_yy      -2.4509      
+Br       2 Eigenvector A_yy      -0.2256     -0.9058     -0.3585
+Br       2 Eigenvalue  A_zz      -3.0635      
+Br       2 Eigenvector A_zz       0.4894     -0.4236      0.7623
+
+Br       2 Iso:       -1.6697 (MHz)
+============
+Atom: H:Mu     1
+============
+H:Mu     1 Coordinates      4.843    6.820   10.012   A
+
+TOTAL tensor
+
+            -442.9169     -0.6934      5.8640
+              -0.6934   -417.3220      3.8139
+               5.8640      3.8139   -434.4749
+
+H:Mu     1 Eigenvalue  A_xx    -416.5004      
+H:Mu     1 Eigenvector A_xx      -0.0220     -0.9765     -0.2144
+H:Mu     1 Eigenvalue  A_yy    -432.0951      
+H:Mu     1 Eigenvector A_yy       0.4767     -0.1987      0.8563
+H:Mu     1 Eigenvalue  A_zz    -446.1183      
+H:Mu     1 Eigenvector A_zz      -0.8788     -0.0834      0.4699
+
+H:Mu     1 Iso:     -431.5713 (MHz)
+[/magres_old]

--- a/test/loader.js
+++ b/test/loader.js
@@ -259,8 +259,122 @@ H 0.0 1.0 0.0`;
         expect(loader.error_message).to.equal('Invalid Magres file format: block opened without closing');
 
     });
-    it('should load properly a CELL file', function() {
 
+    it('should parse hyperfine tensors from magres_old block', function() {
+
+        var loader = new Loader();
+
+        // Test with the synthetic HF tensor test file (non-zero values)
+        var magres = fs.readFileSync(path.join(__dirname, 'data', 'hf_test.magres'), "utf8");
+        var a = loader.load(magres, 'magres')['magres'];
+
+        expect(loader.status).to.equal(Loader.STATUS_SUCCESS);
+        expect(a.length()).to.equal(2);
+
+        // hf array should exist
+        var hf = a.get_array('hf');
+        expect(hf).to.have.lengthOf(2);
+
+        // Each entry should be a TensorData object
+        expect(hf[0]).to.have.property('data');
+        expect(hf[1]).to.have.property('data');
+
+        // Check H 1 tensor matrix values
+        expect(hf[0].data).to.deep.almost.equal([
+            [ 1.2345, -0.5678,  0.1234],
+            [-0.5678,  2.3456,  0.4567],
+            [ 0.1234,  0.4567,  3.4567]
+        ]);
+
+        // Check C 1 tensor matrix values
+        expect(hf[1].data).to.deep.almost.equal([
+            [5.0, 1.0, 0.0],
+            [1.0, 5.0, 0.0],
+            [0.0, 0.0, 3.0]
+        ]);
+
+        // Check isotropic values (trace/3)
+        expect(hf[0].isotropy).to.almost.equal((1.2345 + 2.3456 + 3.4567) / 3);
+        expect(hf[1].isotropy).to.almost.equal((5.0 + 5.0 + 3.0) / 3);
+
+        // Check eigenvalues of C 1 (symmetric: known values 3, 4, 6)
+        var c_evals = hf[1].eigenvalues;
+        expect(c_evals).to.deep.almost.equal([3.0, 4.0, 6.0]);
+
+        // Check gamma ratios parsed from the synthetic file
+        var ratios = a.info['hf-gyromagnetic-ratios'];
+        expect(ratios).to.exist;
+        expect(ratios['H']).to.exist;
+        expect(ratios['H'].isotope).to.equal(1);
+        expect(ratios['H'].gamma).to.almost.equal(2.6752e8);
+        expect(ratios['C']).to.exist;
+        expect(ratios['C'].isotope).to.equal(13);
+        expect(ratios['C'].gamma).to.almost.equal(6.7283e7);
+
+        // Test with optimized_muon_65-hf.magres (real CASTEP output with non-zero HF tensors and H:Mu)
+        var muon_magres = fs.readFileSync(path.join(__dirname, 'data', 'optimized_muon_65-hf.magres'), "utf8");
+        var am = loader.load(muon_magres, 'magres')['magres'];
+
+        expect(am.length()).to.equal(69); // 16 H + 1 H:Mu + 28 C + 4 Fe + 2 N + 12 O + 4 S + 2 Br
+
+        var hf_m = am.get_array('hf');
+        expect(hf_m).to.have.lengthOf(69);
+
+        // All entries should be TensorData objects (not null)
+        hf_m.forEach(function(t) {
+            expect(t).to.have.property('data');
+            expect(t.data).to.have.lengthOf(3);
+        });
+
+        // H 1 tensor values are non-trivial
+        expect(hf_m[0].data).to.deep.almost.equal([
+            [-2.5897,  2.2293,  0.4459],
+            [ 2.2293,  0.8275, -0.5108],
+            [ 0.4459, -0.5108,  0.9140]
+        ]);
+
+        // H:Mu 1 is the last atom; check its isotropy
+        expect(hf_m[68].isotropy).to.almost.equal(-431.5713);
+
+        // Gamma ratios should include H:Mu as user-defined
+        var ratios_m = am.info['hf-gyromagnetic-ratios'];
+        expect(ratios_m['H:Mu'].isotope).to.equal(null);
+        expect(ratios_m['H:Mu'].gamma).to.almost.equal(8.5162e8);
+    });
+    it('should handle custom species (H:Mu) in magres files', function() {
+
+        var loader = new Loader();
+
+        var magres = fs.readFileSync(path.join(__dirname, 'data', 'hf_mu_test.magres'), "utf8");
+        var a = loader.load(magres, 'magres')['magres'];
+
+        expect(loader.status).to.equal(Loader.STATUS_SUCCESS);
+        expect(a.length()).to.equal(2);
+
+        // H:Mu should be stored as element H (colon-suffix stripped)
+        expect(a.get_chemical_symbols()).to.deep.equal(['H', 'H']);
+
+        // Both atoms should have HF tensors
+        var hf = a.get_array('hf');
+        expect(hf).to.have.lengthOf(2);
+        expect(hf[0]).to.have.property('data');
+        expect(hf[1]).to.have.property('data');
+
+        // H 1 tensor is diagonal [1,2,3]
+        expect(hf[0].eigenvalues).to.deep.almost.equal([1.0, 2.0, 3.0]);
+
+        // H:Mu 1 tensor was stored (check isotropy ~ -20)
+        expect(hf[1].isotropy).to.almost.equal((-10 - 20 - 30) / 3);
+
+        // Gamma ratios: standard H and user-defined H:Mu
+        var ratios = a.info['hf-gyromagnetic-ratios'];
+        expect(ratios['H'].isotope).to.equal(1);
+        expect(ratios['H'].gamma).to.almost.equal(2.6752e8);
+        expect(ratios['H:Mu'].isotope).to.equal(null);
+        expect(ratios['H:Mu'].gamma).to.almost.equal(8.5162e8);
+    });
+
+    it('should load properly a CELL file', function() {
         var loader = new Loader();
 
         var cell = fs.readFileSync(path.join(__dirname, 'data', 'ethanol.cell'), "utf8");


### PR DESCRIPTION
Add support for reading hyperfine (HF) coupling tensors written by CASTEP into the free-text `magres_old` block that appears in .magres files from a hyperfine task.

Parser changes (lib/formats/magres.js):
- Add `parseMagresOldBlock()`: a three-state machine that walks the free-text block, recognises each `Atom: SPECIES N` / `TOTAL tensor` section and collects the 3×3 tensor rows.  The subsequent eigenvalue label is inspected to distinguish tensor types: only sections whose eigenvalue line starts with `A_` (hyperfine) are kept; EFG (`V_xx`) and shielding (`TOTAL Shielding Tensor` / `sigma_xx`) are silently skipped.
- Parse the magnetogyric-ratio table that precedes the per-atom sections. Two line formats are handled: `SPECIES  Isotope N  GAMMA = VALUE` and `SPECIES  User defined.  GAMMA = VALUE`.  Results are stored in `atoms.info['hf-gyromagnetic-ratios']`.
- Strip the colon-suffix from custom CASTEP pseudopotential species labels (e.g. `H:Mu` → element `H`) so that `Atoms` does not reject them as unknown elements.  The full label is retained for tensor lookup.
- Store parsed HF tensors via `atoms.set_array('hf', hf_data)`.

Demo (demo/index.html, demo/main.js):
- Add "Show HF ellipsoids" checkbox that calls `addEllipsoids()` with the `hf` array, mirroring the existing MS/EFG ellipsoid controls.

Tests (test/loader.js, test/data/):
- Add "should parse hyperfine tensors from magres_old block" test using the synthetic `hf_test.magres` fixture (2 atoms, known tensor values and gamma ratios) and `optimized_muon_65-hf.magres` (69-atom real CASTEP output including H:Mu, non-zero tensors up to ~450 MHz).
- Add "should handle custom species (H:Mu) in magres files" test using the synthetic `hf_mu_test.magres` fixture.
- Add test data files: hf_test.magres, hf_mu_test.magres, optimized_muon_65-hf.magres.