### PR TITLE
Feat/magresview api additions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "python.pythonPath": "/home/phony_stark/miniconda2/bin/python"
+  "files.watcherExclude": {
+    "**/node_modules/**": true,
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to crystvis-js will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `CrystVis.getCameraState()` / `setCameraState(state)` — snapshot and restore the
+  camera position, target and zoom level as a plain serialisable object.
+- `CrystVis.onCameraChange(callback)` — subscribe to live camera-change events
+  (rotate / pan / zoom); returns an unsubscribe function.
+- `CrystVis.getModelSource(name)` — retrieve the raw file text and extension originally
+  passed to `loadModels()`.
+- `CrystVis.getModelParameters(name)` — retrieve the merged loading parameters used when
+  a model was last loaded or reloaded.
+- `CrystVis.getModelMeta(name)` — retrieve `{ prefix, originalName }` metadata stored at
+  load time.
+- `CrystVis.onModelListChange(callback)` — subscribe to events fired whenever the set of
+  loaded models changes (load, delete, unloadAll); returns an unsubscribe function.
+- `CrystVis.onDisplayChange(callback)` — subscribe to events fired whenever the displayed
+  model changes; callback receives the new model name or `null`.
+- `CrystVis.unloadAll()` — remove all loaded models atomically (one renderer clear, one
+  set of change events).
+- `ModelView.toIndices()` — serialise a selection to a plain index array.
+- `ModelView.toLabels()` — serialise a selection to an array of crystallographic site
+  labels (`crystLabel`), resilient to atom-index reordering.
+- `Model.viewFromIndices(indices)` — reconstruct a `ModelView` from a saved index array.
+- `Model.viewFromLabels(labels)` — reconstruct a `ModelView` from a saved label array.
+- `Renderer.getCameraState()` / `setCameraState(state)` / `onCameraChange(callback)` —
+  lower-level camera state API used by `CrystVis`.
+
 ## [0.6.0] - 2025-07-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,73 @@ if (loaded[modelName] !== 0) {
 }
 ```
 
+### API highlights
+
+Full JSDoc documentation is available at [ccp-nc.github.io/crystvis-js](https://ccp-nc.github.io/crystvis-js/).
+
+#### Camera state — save, restore and react to view changes
+
+```js
+// Snapshot the current camera (position, target, zoom) — plain JSON-serialisable object
+const snap = visualizer.getCameraState();
+// { position: {x,y,z}, target: {x,y,z}, zoom: 1 }
+
+// Restore a previously saved snapshot
+visualizer.setCameraState(snap);
+
+// React to every rotate/pan/zoom (returns an unsubscribe function)
+const unsub = visualizer.onCameraChange(state => {
+    console.log('Camera moved:', state);
+});
+unsub(); // stop listening
+```
+
+#### Lifecycle events — react to model and display changes
+
+```js
+// Fired whenever models are loaded, deleted, or all cleared
+const unsubList = visualizer.onModelListChange(names => {
+    console.log('Loaded models:', names);
+});
+
+// Fired whenever displayModel() completes; receives model name or null
+const unsubDisplay = visualizer.onDisplayChange(name => {
+    console.log('Now displaying:', name);
+});
+
+// Remove all loaded models in one atomic operation
+visualizer.unloadAll();
+```
+
+#### Model metadata — access source and parameters after loading
+
+```js
+// Retrieve the raw file text and extension originally passed to loadModels()
+const src = visualizer.getModelSource(modelName);
+// { text: '...', extension: 'cif' }
+
+// Retrieve the merged loading parameters (supercell, molecularCrystal, …)
+const params = visualizer.getModelParameters(modelName);
+
+// Retrieve prefix and original structure name
+const meta = visualizer.getModelMeta(modelName);
+// { prefix: 'cif', originalName: 'struct' }
+```
+
+#### Selection serialisation — save and reconstruct atom subsets
+
+```js
+// Serialise a selection to plain data
+const indices = visualizer.selected.toIndices(); // number[]
+const labels  = visualizer.selected.toLabels();  // string[] (crystLabel per atom)
+
+// Reconstruct from indices later
+visualizer.selected = visualizer.model.viewFromIndices(indices);
+
+// Reconstruct from labels — resilient to atom-index reordering on reload
+visualizer.selected = visualizer.model.viewFromLabels(labels);
+```
+
 ### Preparing for development
 
 If you want to develop for crystvis-js, you should follow these steps:

--- a/demo/index.html
+++ b/demo/index.html
@@ -79,6 +79,27 @@
                             </td>
                             
                         </tr>
+                        <tr>
+                            <td colspan="2"><hr style="margin:6px 0"><strong>Camera state</strong></td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <input type="button" value="Save view" onclick="saveCamera()">
+                                <input type="button" value="Restore view" onclick="restoreCamera()">
+                            </td>
+                            <td>
+                                <input type="button" value="Copy JSON" onclick="copyCameraJSON()">
+                                <input type="button" value="Apply JSON" onclick="applyPastedJSON()">
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="2">
+                                <textarea id="camera-json" rows="5" style="width:100%;font-family:monospace;font-size:11px;box-sizing:border-box" placeholder="Camera state will appear here…" spellcheck="false"></textarea>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="2" id="camera-status" style="font-size:11px;color:#555"></td>
+                        </tr>
                    </tbody>
            </table> 
            <div id='colorgrid'>

--- a/demo/main.js
+++ b/demo/main.js
@@ -171,3 +171,67 @@ window.displayMessage = function() {
 window.clearMessages = function() {
     visualizer.clearNotifications();
 }
+
+// ─── Camera state demo ───────────────────────────────────────────────────────
+
+// Keep a snapshot of the last saved camera state so Restore can use it.
+var _savedCameraState = null;
+
+/** Pretty-print a camera state snapshot into the textarea. */
+function updateCameraTextarea(state) {
+    var ta = document.getElementById('camera-json');
+    if (ta) ta.value = JSON.stringify(state, null, 2);
+}
+
+/** Mark the status line briefly then clear it. */
+function setCameraStatus(msg) {
+    var el = document.getElementById('camera-status');
+    if (!el) return;
+    el.textContent = msg;
+    clearTimeout(el._timer);
+    el._timer = setTimeout(() => { el.textContent = ''; }, 2500);
+}
+
+// Live-update the textarea whenever the user rotates / pans / zooms.
+visualizer.onCameraChange(function(state) {
+    updateCameraTextarea(state);
+});
+
+/** Save the current camera position so it can be restored later. */
+window.saveCamera = function() {
+    _savedCameraState = visualizer.getCameraState();
+    updateCameraTextarea(_savedCameraState);
+    setCameraStatus('View saved.');
+};
+
+/** Restore the most recently saved camera snapshot. */
+window.restoreCamera = function() {
+    if (!_savedCameraState) {
+        setCameraStatus('Nothing saved yet — click Save view first.');
+        return;
+    }
+    visualizer.setCameraState(_savedCameraState);
+    setCameraStatus('View restored.');
+};
+
+/** Copy the current textarea JSON to the clipboard. */
+window.copyCameraJSON = function() {
+    var ta = document.getElementById('camera-json');
+    if (!ta || !ta.value) { setCameraStatus('Nothing to copy yet.'); return; }
+    navigator.clipboard.writeText(ta.value)
+        .then(() => setCameraStatus('Copied to clipboard.'))
+        .catch(() => { ta.select(); document.execCommand('copy'); setCameraStatus('Copied (fallback).'); });
+};
+
+/** Parse whatever is in the textarea and apply it as the camera state. */
+window.applyPastedJSON = function() {
+    var ta = document.getElementById('camera-json');
+    if (!ta || !ta.value) { setCameraStatus('Textarea is empty.'); return; }
+    try {
+        var state = JSON.parse(ta.value);
+        visualizer.setCameraState(state);
+        setCameraStatus('Camera state applied.');
+    } catch (e) {
+        setCameraStatus('Invalid JSON: ' + e.message);
+    }
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -1777,6 +1777,37 @@ class Model {
     }
 
     /**
+     * Reconstruct a {@link ModelView} from a plain array of atom-image indices,
+     * as produced by {@link ModelView#toIndices}.  This is the stable public API
+     * for deserialising a saved selection.
+     *
+     * @param  {number[]} indices
+     * @return {ModelView}
+     */
+    viewFromIndices(indices = []) {
+        return this.view(indices);
+    }
+
+    /**
+     * Reconstruct a {@link ModelView} from an array of crystallographic site
+     * labels (`crystLabel`), as produced by {@link ModelView#toLabels}.  This
+     * is resilient to atom-index reordering across reloads.
+     *
+     * @param  {string[]} labels
+     * @return {ModelView}
+     */
+    viewFromLabels(labels = []) {
+        const wanted = new Set(labels);
+        const indices = [];
+        for (let i = 0; i < this._atom_images.length; ++i) {
+            if (wanted.has(this._atom_images[i].crystLabel)) {
+                indices.push(i);
+            }
+        }
+        return this.view(indices);
+    }
+
+    /**
      * Set a property on a series of atom images
      *
      * @private

--- a/lib/modelview.js
+++ b/lib/modelview.js
@@ -440,6 +440,30 @@ class ModelView {
             return this;
     }
 
+    // ─── Serialisation helpers ───────────────────────────────────────────────────
+
+    /**
+     * Return a plain array of the atom-image indices in this view.
+     * Use this to serialise a selection; restore it with
+     * {@link Model#viewFromIndices}.
+     *
+     * @return {number[]}
+     */
+    toIndices() {
+        return Array.from(this._indices);
+    }
+
+    /**
+     * Return the crystallographic site labels (`crystLabel`) of the atoms
+     * in this view.  Use this to serialise a selection in a way that is
+     * robust to atom reordering; restore with {@link Model#viewFromLabels}.
+     *
+     * @return {string[]}
+     */
+    toLabels() {
+        return this._images.map(a => a.crystLabel);
+    }
+
 }
 
 export {

--- a/lib/render.js
+++ b/lib/render.js
@@ -456,6 +456,58 @@ class Renderer {
         return this._oc.target;
     }
 
+    /**
+     * Return a plain serialisable snapshot of the current camera state.
+     *
+     * @return {{ position: {x,y,z}, target: {x,y,z}, zoom: number }}
+     */
+    getCameraState() {
+        const pos = this._c.position;
+        const tgt = this._oc.target;
+        return {
+            position: { x: pos.x, y: pos.y, z: pos.z },
+            target:   { x: tgt.x, y: tgt.y, z: tgt.z },
+            zoom:     this._c.zoom,
+        };
+    }
+
+    /**
+     * Restore a camera snapshot produced by {@link Renderer#getCameraState}.
+     *
+     * @param {{ position?: {x,y,z}, target?: {x,y,z}, zoom?: number }} state
+     */
+    setCameraState(state) {
+        if (!state) return;
+
+        if (state.position) {
+            this._c.position.set(state.position.x, state.position.y, state.position.z);
+        }
+        if (state.target) {
+            this._oc.target.set(state.target.x, state.target.y, state.target.z);
+        }
+        if (typeof state.zoom === 'number') {
+            this._c.zoom = state.zoom;
+            this._c.updateProjectionMatrix();
+        }
+        this._oc.update();
+    }
+
+    /**
+     * Subscribe to camera-change events fired by OrbitControls whenever
+     * the user rotates, pans, or zooms.  The callback receives a camera
+     * state snapshot identical to the one returned by {@link Renderer#getCameraState}.
+     *
+     * @param  {Function} callback  `callback(cameraState)` called on each change
+     * @return {Function}           Unsubscribe function — call it to remove the listener
+     */
+    onCameraChange(callback) {
+        const handler = () => callback(this.getCameraState());
+        this._oc.addEventListener('change', handler);
+        return () => {
+            if (this._oc) this._oc.removeEventListener('change', handler);
+        };
+    }
+
 
     /**
      * Remove all currently rendered objects.

--- a/lib/visualizer.js
+++ b/lib/visualizer.js
@@ -368,7 +368,7 @@ class CrystVis {
      */
     getModelSource(name) {
         const src = this._model_sources[name];
-        return src ? _.cloneDeep(src) : null;
+        return src ? { ...src } : null;
     }
 
     /**
@@ -380,7 +380,7 @@ class CrystVis {
      */
     getModelParameters(name) {
         const p = this._model_parameters[name];
-        return p ? _.cloneDeep(p) : null;
+        return p ? JSON.parse(JSON.stringify(p)) : null;
     }
 
     /**
@@ -392,7 +392,7 @@ class CrystVis {
      */
     getModelMeta(name) {
         const m = this._model_meta[name];
-        return m ? _.cloneDeep(m) : null;
+        return m ? { ...m } : null;
     }
 
     // ─── Atomic unload ───────────────────────────────────────────────────────────
@@ -599,7 +599,7 @@ class CrystVis {
             }
             this._models[nn] = new Model(s, parameters);
             this._model_sources[nn]     = { text: contents, extension: format };
-            this._model_parameters[nn]  = _.cloneDeep(parameters);
+            this._model_parameters[nn]  = JSON.parse(JSON.stringify(parameters));
             this._model_meta[nn]        = { prefix: prefix, originalName: n };
             status[nn] = 0; // Success
         }
@@ -635,7 +635,7 @@ class CrystVis {
         parameters = _.merge(model_parameter_defaults, parameters);
 
         this._models[name] = new Model(s, parameters);
-        this._model_parameters[name] = _.cloneDeep(parameters);
+        this._model_parameters[name] = JSON.parse(JSON.stringify(parameters));
 
         if (current) {
             this.displayModel(name);

--- a/lib/visualizer.js
+++ b/lib/visualizer.js
@@ -88,6 +88,21 @@ class CrystVis {
         // Disposal state
         this._isDisposed = false;
 
+        // Model source / parameter / metadata stores (keyed by model name)
+        this._model_sources = {};     // { text, extension }
+        this._model_parameters = {};  // parameters passed to loadModels / reloadModel
+        this._model_meta = {};        // { prefix, originalName }
+
+        // Lifecycle / camera-change callbacks
+        this._model_list_change_cbs = [];
+        this._display_change_cbs    = [];
+        this._camera_change_cbs     = [];
+
+        // Subscribe to camera changes from the renderer
+        this._camera_unsub = this._renderer.onCameraChange((state) => {
+            this._camera_change_cbs.forEach(cb => cb(state));
+        });
+
     }
 
     /**
@@ -266,6 +281,146 @@ class CrystVis {
             this._atom_box_event = this._defaultAtomBox.bind(this);
     }
 
+    // ─── Private event emitters ─────────────────────────────────────────────────
+
+    _emitModelListChange() {
+        const names = Object.keys(this._models);
+        this._model_list_change_cbs.forEach(cb => cb(names));
+    }
+
+    _emitDisplayChange() {
+        this._display_change_cbs.forEach(cb => cb(this._current_mname));
+    }
+
+    // ─── Camera state API ────────────────────────────────────────────────────────
+
+    /**
+     * Return a plain serialisable snapshot of the current camera state.
+     *
+     * @return {{ position: {x,y,z}, target: {x,y,z}, zoom: number }}
+     */
+    getCameraState() {
+        return this._renderer.getCameraState();
+    }
+
+    /**
+     * Restore a camera snapshot produced by {@link CrystVis#getCameraState}.
+     * Safe to call after `displayModel()`.
+     *
+     * @param {{ position?: {x,y,z}, target?: {x,y,z}, zoom?: number }} state
+     */
+    setCameraState(state) {
+        this._renderer.setCameraState(state);
+    }
+
+    /**
+     * Subscribe to camera-change events (rotate, pan, zoom).
+     * The callback receives a snapshot identical to {@link CrystVis#getCameraState}.
+     *
+     * @param  {Function} callback  `callback(cameraState)`
+     * @return {Function}           Unsubscribe function
+     */
+    onCameraChange(callback) {
+        this._camera_change_cbs.push(callback);
+        return () => {
+            this._camera_change_cbs = this._camera_change_cbs.filter(cb => cb !== callback);
+        };
+    }
+
+    // ─── Lifecycle event APIs ────────────────────────────────────────────────────
+
+    /**
+     * Subscribe to model-list change events (model added or deleted).
+     * The callback receives the new list of model names.
+     *
+     * @param  {Function} callback  `callback(modelNames: string[])`
+     * @return {Function}           Unsubscribe function
+     */
+    onModelListChange(callback) {
+        this._model_list_change_cbs.push(callback);
+        return () => {
+            this._model_list_change_cbs = this._model_list_change_cbs.filter(cb => cb !== callback);
+        };
+    }
+
+    /**
+     * Subscribe to display-change events fired whenever `displayModel()` completes.
+     * The callback receives the name of the newly displayed model (or `null` when cleared).
+     *
+     * @param  {Function} callback  `callback(modelName: string|null)`
+     * @return {Function}           Unsubscribe function
+     */
+    onDisplayChange(callback) {
+        this._display_change_cbs.push(callback);
+        return () => {
+            this._display_change_cbs = this._display_change_cbs.filter(cb => cb !== callback);
+        };
+    }
+
+    // ─── Model source / parameter / metadata APIs ────────────────────────────────
+
+    /**
+     * Return the raw file text and format extension originally passed to
+     * `loadModels()` for the named model.
+     *
+     * @param  {String} name  Model name
+     * @return {{ text: string, extension: string }|null}
+     */
+    getModelSource(name) {
+        const src = this._model_sources[name];
+        return src ? _.cloneDeep(src) : null;
+    }
+
+    /**
+     * Return the loading parameters that were used when the named model was
+     * last loaded / reloaded (a clone of the merged parameter object).
+     *
+     * @param  {String} name  Model name
+     * @return {Object|null}
+     */
+    getModelParameters(name) {
+        const p = this._model_parameters[name];
+        return p ? _.cloneDeep(p) : null;
+    }
+
+    /**
+     * Return metadata stored alongside the named model:
+     * `{ prefix, originalName }`.
+     *
+     * @param  {String} name  Model name
+     * @return {{ prefix: string, originalName: string }|null}
+     */
+    getModelMeta(name) {
+        const m = this._model_meta[name];
+        return m ? _.cloneDeep(m) : null;
+    }
+
+    // ─── Atomic unload ───────────────────────────────────────────────────────────
+
+    /**
+     * Remove *all* loaded models and reset the view in a single atomic operation
+     * (only one render pass after everything is cleared, unlike calling
+     * `deleteModel()` in a loop).
+     */
+    unloadAll() {
+        if (this._isDisposed) {
+            throw new Error('CrystVis: cannot call unloadAll() on a disposed instance');
+        }
+
+        // Clear the displayed model (handles renderer.clear(), selection reset, etc.)
+        // displayModel() with no args also emits _emitDisplayChange()
+        this.displayModel();
+
+        this._models           = {};
+        this._model_sources    = {};
+        this._model_parameters = {};
+        this._model_meta       = {};
+
+        this._emitModelListChange();
+    }
+
+    // ─── Internal atom-click/box defaults ────────────────────────────────────────
+
     _defaultAtomLeftClick(atom, event) {
         var i = atom.imgIndex;
         this.selected = new ModelView(this._current_model, [i]);
@@ -340,6 +495,12 @@ class CrystVis {
         }
         this._isDisposed = true;
 
+        // Unsubscribe camera-change listener before tearing down the renderer
+        if (this._camera_unsub) {
+            this._camera_unsub();
+            this._camera_unsub = null;
+        }
+
         // Tear down the renderer (animation loop, orbit controls, WebGL context)
         if (this._renderer) {
             this._renderer.dispose();
@@ -352,12 +513,18 @@ class CrystVis {
         this._displayed = null;
         this._selected = null;
         this._models = {};
+        this._model_sources = {};
+        this._model_parameters = {};
+        this._model_meta = {};
 
         // Drop event callbacks
         this._atom_click_events = {};
         this._atom_click_defaults = {};
         this._atom_box_event = null;
         this._notifications = [];
+        this._model_list_change_cbs = [];
+        this._display_change_cbs    = [];
+        this._camera_change_cbs     = [];
     }
 
     centerCamera(center = [0, 0, 0], shift = [0, 0]) {
@@ -431,9 +598,13 @@ class CrystVis {
                 continue;
             }
             this._models[nn] = new Model(s, parameters);
+            this._model_sources[nn]     = { text: contents, extension: format };
+            this._model_parameters[nn]  = _.cloneDeep(parameters);
+            this._model_meta[nn]        = { prefix: prefix, originalName: n };
             status[nn] = 0; // Success
         }
 
+        this._emitModelListChange();
         return status;
     }
 
@@ -464,6 +635,7 @@ class CrystVis {
         parameters = _.merge(model_parameter_defaults, parameters);
 
         this._models[name] = new Model(s, parameters);
+        this._model_parameters[name] = _.cloneDeep(parameters);
 
         if (current) {
             this.displayModel(name);
@@ -493,6 +665,7 @@ class CrystVis {
 
         if (!name) {
             // If called with nothing, just quit here
+            this._emitDisplayChange();
             return;
         }
 
@@ -522,6 +695,7 @@ class CrystVis {
         this._renderer.resetOrbitCenter(c[0], c[1], c[2]);
 
         this._displayed.show();
+        this._emitDisplayChange();
     }
 
     /**
@@ -540,6 +714,10 @@ class CrystVis {
         }
 
         delete this._models[name];
+        delete this._model_sources[name];
+        delete this._model_parameters[name];
+        delete this._model_meta[name];
+        this._emitModelListChange();
     }
 
     /**

--- a/test/model.js
+++ b/test/model.js
@@ -395,3 +395,121 @@ describe('#modelview', function() {
             expect(newMV._indices.sort()).to.deep.equal([72]);   
     });
 });
+
+// ---------------------------------------------------------------------------
+// Tests: ModelView serialisation (§6.1, §6.3) and Model reconstruction (§6.2, §6.3)
+// ---------------------------------------------------------------------------
+
+describe('ModelView#toIndices', function() {
+
+    it('returns a plain array equal to the view indices', function() {
+        var mv = h2omodel.find({ elements: ['O'] });
+        var result = mv.toIndices();
+        expect(result).to.deep.equal(mv.indices);
+    });
+
+    it('returns a copy — mutating it does not affect the view', function() {
+        var mv = h2omodel.find({ elements: ['O'] });
+        var result = mv.toIndices();
+        result.push(999);
+        expect(mv.indices.length).to.equal(result.length - 1);
+    });
+
+    it('returns an empty array for an empty view', function() {
+        var mv = h2omodel.view([]);
+        expect(mv.toIndices()).to.deep.equal([]);
+    });
+
+});
+
+describe('ModelView#toLabels', function() {
+
+    it('returns one crystLabel per atom in the view', function() {
+        var mv = h2omodel.find({ elements: ['O'] });
+        var labels = mv.toLabels();
+        expect(labels).to.be.an('array');
+        expect(labels.length).to.equal(mv.length);
+        labels.forEach(l => expect(l).to.be.a('string').and.have.length.above(0));
+    });
+
+    it('all labels contain the element symbol', function() {
+        var mv = h2omodel.find({ elements: ['H'] });
+        mv.toLabels().forEach(l => expect(l).to.match(/^H/));
+    });
+
+    it('returns an empty array for an empty view', function() {
+        var mv = h2omodel.view([]);
+        expect(mv.toLabels()).to.deep.equal([]);
+    });
+
+    it('round-trips: toLabels then viewFromLabels gives the same indices', function() {
+        // Use a multi-site structure for a meaningful round-trip
+        var mv = chamodel.find({ elements: ['O'] });
+        var labels = mv.toLabels();
+        var restored = chamodel.viewFromLabels(labels);
+        expect(restored.indices.sort((a,b)=>a-b))
+            .to.deep.equal(mv.indices.slice().sort((a,b)=>a-b));
+    });
+
+});
+
+describe('Model#viewFromIndices', function() {
+
+    it('produces a view with exactly the specified indices', function() {
+        var indices = [0, 2, 4];
+        var mv = h2omodel.viewFromIndices(indices);
+        expect(mv.indices).to.deep.equal(indices);
+    });
+
+    it('is equivalent to model.view(indices)', function() {
+        var indices = [1, 3];
+        var a = h2omodel.viewFromIndices(indices);
+        var b = h2omodel.view(indices);
+        expect(a.indices).to.deep.equal(b.indices);
+    });
+
+    it('defaults to an empty view when called with no arguments', function() {
+        var mv = h2omodel.viewFromIndices();
+        expect(mv.length).to.equal(0);
+    });
+
+    it('round-trips with toIndices()', function() {
+        var original = h2omodel.find({ elements: ['H'] });
+        var restored = h2omodel.viewFromIndices(original.toIndices());
+        expect(restored.indices).to.deep.equal(original.indices);
+    });
+
+});
+
+describe('Model#viewFromLabels', function() {
+
+    it('finds atoms matching the given labels', function() {
+        var mv = chamodel.find({ elements: ['Si'] });
+        var labels = mv.toLabels();
+        var restored = chamodel.viewFromLabels(labels);
+        expect(restored.length).to.equal(mv.length);
+    });
+
+    it('returns an empty view for an empty label array', function() {
+        var mv = chamodel.viewFromLabels([]);
+        expect(mv.length).to.equal(0);
+    });
+
+    it('ignores unknown labels', function() {
+        // Grab a real label dynamically, then mix it with a nonsense one
+        var validLabel = chamodel._atom_images[0].crystLabel;
+        var mv = chamodel.viewFromLabels([validLabel, 'DOES_NOT_EXIST']);
+        expect(mv.length).to.be.greaterThan(0);
+        mv.toLabels().forEach(l => expect(l).to.not.equal('DOES_NOT_EXIST'));
+    });
+
+    it('round-trips with toLabels() across a different supercell model', function() {
+        // Use the unit-cell model to get labels, then restore on the same model
+        var mv = chamodel.find({ elements: ['O'] });
+        var labels = mv.toLabels();
+        var restored = chamodel.viewFromLabels(labels);
+        expect(restored.indices.sort((a,b)=>a-b))
+            .to.deep.equal(mv.indices.slice().sort((a,b)=>a-b));
+    });
+
+});

--- a/test/visualizer.js
+++ b/test/visualizer.js
@@ -26,6 +26,9 @@ function makeMockRenderer() {
     const renderer = {
         _disposed: false,
         _disposeCalls: 0,
+        _setCameraStateCalls: [],
+        _cameraChangeHandlers: [],
+        _cameraState: { position: { x: 0, y: 0, z: 10 }, target: { x: 0, y: 0, z: 0 }, zoom: 1 },
         dispose() {
             this._disposed = true;
             this._disposeCalls++;
@@ -36,6 +39,27 @@ function makeMockRenderer() {
         resetOrbitCenter() {},
         add() {},
         remove() {},
+        getCameraState() {
+            return Object.assign({}, this._cameraState,
+                { position: Object.assign({}, this._cameraState.position),
+                  target:   Object.assign({}, this._cameraState.target) });
+        },
+        setCameraState(state) {
+            this._setCameraStateCalls.push(state);
+            if (state) Object.assign(this._cameraState, state);
+        },
+        onCameraChange(cb) {
+            this._cameraChangeHandlers.push(cb);
+            return () => {
+                this._cameraChangeHandlers =
+                    this._cameraChangeHandlers.filter(h => h !== cb);
+            };
+        },
+        /** Trigger all registered camera-change handlers (test helper). */
+        _fireCameraChange() {
+            const state = this.getCameraState();
+            this._cameraChangeHandlers.forEach(h => h(state));
+        },
     };
     return renderer;
 }
@@ -65,6 +89,19 @@ function makeMockVis(mockRenderer) {
     vis._atom_box_event = null;
     vis._hsel = false;
     vis.cifsymtol = 1e-2;
+
+    // New state added by this batch of features
+    vis._model_sources    = {};
+    vis._model_parameters = {};
+    vis._model_meta       = {};
+    vis._model_list_change_cbs = [];
+    vis._display_change_cbs    = [];
+    vis._camera_change_cbs     = [];
+    // Wire the renderer's camera-change signal to the vis callback array,
+    // mirroring what the real constructor does.
+    vis._camera_unsub = r.onCameraChange((state) => {
+        vis._camera_change_cbs.forEach(cb => cb(state));
+    });
 
     return { vis, renderer: r };
 }
@@ -107,6 +144,36 @@ describe('CrystVis#dispose', function () {
         vis._models = { a: {}, b: {} };
         vis.dispose();
         expect(Object.keys(vis._models)).to.have.length(0);
+    });
+
+    it('should clear model source / parameter / meta stores', function () {
+        const { vis } = makeMockVis();
+        vis._model_sources    = { a: { text: 'x', extension: 'cif' } };
+        vis._model_parameters = { a: { supercell: [1,1,1] } };
+        vis._model_meta       = { a: { prefix: 'cif', originalName: 'a' } };
+        vis.dispose();
+        expect(Object.keys(vis._model_sources)).to.have.length(0);
+        expect(Object.keys(vis._model_parameters)).to.have.length(0);
+        expect(Object.keys(vis._model_meta)).to.have.length(0);
+    });
+
+    it('should clear lifecycle and camera-change callback arrays', function () {
+        const { vis } = makeMockVis();
+        vis._model_list_change_cbs.push(() => {});
+        vis._display_change_cbs.push(() => {});
+        vis._camera_change_cbs.push(() => {});
+        vis.dispose();
+        expect(vis._model_list_change_cbs).to.have.length(0);
+        expect(vis._display_change_cbs).to.have.length(0);
+        expect(vis._camera_change_cbs).to.have.length(0);
+    });
+
+    it('should unsubscribe from renderer camera-change on dispose', function () {
+        const { vis, renderer } = makeMockVis();
+        // One handler was registered by makeMockVis wiring
+        expect(renderer._cameraChangeHandlers).to.have.length(1);
+        vis.dispose();
+        expect(renderer._cameraChangeHandlers).to.have.length(0);
     });
 
     it('should clear atom event callbacks', function () {
@@ -158,6 +225,14 @@ describe('CrystVis#isDisposed guard', function () {
         );
     });
 
+    it('unloadAll() should throw after disposal', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(() => vis.unloadAll()).to.throw(
+            /cannot call unloadAll\(\) on a disposed instance/
+        );
+    });
+
     it('isDisposed getter returns false before disposal', function () {
         const { vis } = makeMockVis();
         expect(vis.isDisposed).to.be.false;
@@ -167,6 +242,234 @@ describe('CrystVis#isDisposed guard', function () {
         const { vis } = makeMockVis();
         vis.dispose();
         expect(vis.isDisposed).to.be.true;
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Tests: camera state (§1)
+// ---------------------------------------------------------------------------
+
+describe('CrystVis#getCameraState / setCameraState', function () {
+
+    it('getCameraState() delegates to the renderer', function () {
+        const { vis, renderer } = makeMockVis();
+        const state = vis.getCameraState();
+        expect(state).to.deep.equal(renderer._cameraState);
+    });
+
+    it('getCameraState() returns a snapshot (not the live object)', function () {
+        const { vis, renderer } = makeMockVis();
+        const state = vis.getCameraState();
+        // Mutate the returned snapshot – the renderer's state must not change
+        state.zoom = 999;
+        expect(renderer._cameraState.zoom).to.not.equal(999);
+    });
+
+    it('setCameraState() delegates to the renderer', function () {
+        const { vis, renderer } = makeMockVis();
+        const newState = { position: { x: 1, y: 2, z: 3 }, target: { x: 0, y: 0, z: 0 }, zoom: 2 };
+        vis.setCameraState(newState);
+        expect(renderer._setCameraStateCalls).to.have.length(1);
+        expect(renderer._setCameraStateCalls[0]).to.equal(newState);
+    });
+
+});
+
+describe('CrystVis#onCameraChange', function () {
+
+    it('registers a callback that fires when the renderer emits a camera change', function () {
+        const { vis, renderer } = makeMockVis();
+        const received = [];
+        vis.onCameraChange(state => received.push(state));
+        renderer._fireCameraChange();
+        expect(received).to.have.length(1);
+        expect(received[0]).to.have.keys(['position', 'target', 'zoom']);
+    });
+
+    it('supports multiple subscribers', function () {
+        const { vis, renderer } = makeMockVis();
+        let countA = 0, countB = 0;
+        vis.onCameraChange(() => countA++);
+        vis.onCameraChange(() => countB++);
+        renderer._fireCameraChange();
+        expect(countA).to.equal(1);
+        expect(countB).to.equal(1);
+    });
+
+    it('returned unsubscribe function stops future callbacks', function () {
+        const { vis, renderer } = makeMockVis();
+        const received = [];
+        const unsub = vis.onCameraChange(state => received.push(state));
+        renderer._fireCameraChange(); // fires once
+        unsub();
+        renderer._fireCameraChange(); // should NOT reach the callback
+        expect(received).to.have.length(1);
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Tests: model source / parameters / metadata (§2, §3)
+// ---------------------------------------------------------------------------
+
+describe('CrystVis#getModelSource / getModelParameters / getModelMeta', function () {
+
+    it('getModelSource() returns null for unknown model', function () {
+        const { vis } = makeMockVis();
+        expect(vis.getModelSource('missing')).to.be.null;
+    });
+
+    it('getModelSource() returns a cloned copy of stored source', function () {
+        const { vis } = makeMockVis();
+        vis._model_sources['m'] = { text: 'data...', extension: 'cif' };
+        const src = vis.getModelSource('m');
+        expect(src).to.deep.equal({ text: 'data...', extension: 'cif' });
+        // Mutating the returned copy must not affect the store
+        src.text = 'modified';
+        expect(vis._model_sources['m'].text).to.equal('data...');
+    });
+
+    it('getModelParameters() returns null for unknown model', function () {
+        const { vis } = makeMockVis();
+        expect(vis.getModelParameters('missing')).to.be.null;
+    });
+
+    it('getModelParameters() returns a cloned copy of stored parameters', function () {
+        const { vis } = makeMockVis();
+        vis._model_parameters['m'] = { supercell: [2, 2, 1], molecularCrystal: true };
+        const params = vis.getModelParameters('m');
+        expect(params).to.deep.equal({ supercell: [2, 2, 1], molecularCrystal: true });
+        params.supercell[0] = 99;
+        expect(vis._model_parameters['m'].supercell[0]).to.equal(2);
+    });
+
+    it('getModelMeta() returns null for unknown model', function () {
+        const { vis } = makeMockVis();
+        expect(vis.getModelMeta('missing')).to.be.null;
+    });
+
+    it('getModelMeta() returns a cloned copy of stored metadata', function () {
+        const { vis } = makeMockVis();
+        vis._model_meta['m'] = { prefix: 'cif', originalName: 'struct' };
+        const meta = vis.getModelMeta('m');
+        expect(meta).to.deep.equal({ prefix: 'cif', originalName: 'struct' });
+        meta.prefix = 'changed';
+        expect(vis._model_meta['m'].prefix).to.equal('cif');
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Tests: lifecycle events (§4)
+// ---------------------------------------------------------------------------
+
+describe('CrystVis#onModelListChange', function () {
+
+    it('fires with the current model-name list', function () {
+        const { vis } = makeMockVis();
+        vis._models = { a: {}, b: {} };
+        const received = [];
+        vis.onModelListChange(names => received.push(names));
+        vis._emitModelListChange();
+        expect(received).to.have.length(1);
+        expect(received[0].sort()).to.deep.equal(['a', 'b']);
+    });
+
+    it('fires when deleteModel is called', function () {
+        const { vis } = makeMockVis();
+        // Inject a stub model that deleteModel won't choke on
+        vis._models = { m: {} };
+        // displayModel() (called inside deleteModel when current) calls renderer.clear()
+        // and _emitDisplayChange – fine with our mock
+        const received = [];
+        vis.onModelListChange(names => received.push(names.slice()));
+        vis.deleteModel('m');
+        expect(received).to.have.length(1);
+        expect(received[0]).to.deep.equal([]);
+    });
+
+    it('returned unsubscribe function prevents future callbacks', function () {
+        const { vis } = makeMockVis();
+        vis._models = { a: {} };
+        const received = [];
+        const unsub = vis.onModelListChange(names => received.push(names));
+        vis._emitModelListChange();
+        unsub();
+        vis._emitModelListChange();
+        expect(received).to.have.length(1);
+    });
+
+});
+
+describe('CrystVis#onDisplayChange', function () {
+
+    it('fires with null when displayModel() is called with no args', function () {
+        const { vis } = makeMockVis();
+        const received = [];
+        vis.onDisplayChange(name => received.push(name));
+        vis.displayModel(); // clear
+        expect(received).to.have.length(1);
+        expect(received[0]).to.be.null;
+    });
+
+    it('returned unsubscribe function prevents future callbacks', function () {
+        const { vis } = makeMockVis();
+        const received = [];
+        const unsub = vis.onDisplayChange(name => received.push(name));
+        vis.displayModel();
+        unsub();
+        vis.displayModel();
+        expect(received).to.have.length(1);
+    });
+
+});
+
+// ---------------------------------------------------------------------------
+// Tests: unloadAll (§5)
+// ---------------------------------------------------------------------------
+
+describe('CrystVis#unloadAll', function () {
+
+    it('clears all model stores', function () {
+        const { vis } = makeMockVis();
+        vis._models           = { a: {}, b: {} };
+        vis._model_sources    = { a: { text: 'x', extension: 'cif' }, b: { text: 'y', extension: 'xyz' } };
+        vis._model_parameters = { a: {}, b: {} };
+        vis._model_meta       = { a: {}, b: {} };
+
+        vis.unloadAll();
+
+        expect(Object.keys(vis._models)).to.have.length(0);
+        expect(Object.keys(vis._model_sources)).to.have.length(0);
+        expect(Object.keys(vis._model_parameters)).to.have.length(0);
+        expect(Object.keys(vis._model_meta)).to.have.length(0);
+    });
+
+    it('emits onModelListChange with an empty list', function () {
+        const { vis } = makeMockVis();
+        vis._models = { a: {} };
+        const received = [];
+        vis.onModelListChange(names => received.push(names.slice()));
+        vis.unloadAll();
+        expect(received).to.have.length(1);
+        expect(received[0]).to.deep.equal([]);
+    });
+
+    it('emits onDisplayChange with null', function () {
+        const { vis } = makeMockVis();
+        vis._models = { a: {} };
+        const received = [];
+        vis.onDisplayChange(name => received.push(name));
+        vis.unloadAll();
+        expect(received).to.have.length(1);
+        expect(received[0]).to.be.null;
+    });
+
+    it('throws after disposal', function () {
+        const { vis } = makeMockVis();
+        vis.dispose();
+        expect(() => vis.unloadAll()).to.throw(/cannot call unloadAll\(\) on a disposed instance/);
     });
 
 });


### PR DESCRIPTION
This pull request introduces a suite of new APIs to the `CrystVis` visualizer library, enhancing its ability to manage camera state, model lifecycle events, model metadata, and selection serialization. These additions make it easier to snapshot and restore views, react to model and display changes, access model source and parameters, and serialize/deserialize atom selections. The demo and documentation have been updated to showcase these features.

**Camera state management:**

* Added `getCameraState()` and `setCameraState(state)` methods to `CrystVis` and `Renderer` for snapshotting and restoring camera position, target, and zoom as plain objects. [[1]](diffhunk://#diff-dca017847363a6c8765cd0f6df56d69d4d59641c82d7e654979e72997c7e6473R459-R510) [[2]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R284-R423)
* Introduced `onCameraChange(callback)` to subscribe to live camera-change events (rotate/pan/zoom), with an unsubscribe function. [[1]](diffhunk://#diff-dca017847363a6c8765cd0f6df56d69d4d59641c82d7e654979e72997c7e6473R459-R510) [[2]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R284-R423)
* Demo and documentation updated to illustrate camera state features. [[1]](diffhunk://#diff-b18ccd15ec95e2a9c4fead5bca9085042af688361a24d3463c27138e3c797a5bR82-R102) [[2]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR174-R237) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R34) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R122)

**Model lifecycle and metadata APIs:**

* Added `onModelListChange(callback)` and `onDisplayChange(callback)` for subscribing to model list and display changes, with unsubscribe support.
* Introduced `getModelSource(name)`, `getModelParameters(name)`, and `getModelMeta(name)` to retrieve original file text, loading parameters, and metadata for loaded models.
* Implemented `unloadAll()` for atomic removal of all loaded models and triggering change events.

**Selection serialization:**

* Added `ModelView.toIndices()` and `ModelView.toLabels()` for serializing atom selections to index arrays or crystallographic site labels.
* Introduced `Model.viewFromIndices(indices)` and `Model.viewFromLabels(labels)` for reconstructing selections from serialized data, resilient to atom reordering.

**Internal event and state management:**

* Enhanced internal event emitter logic for model list and display changes, ensuring callbacks are fired appropriately during model load, unload, and display operations. [[1]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R284-R423) [[2]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R601-R607) [[3]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R638) [[4]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R668) [[5]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R698) [[6]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R717-R720)
* Improved cleanup logic in `dispose()` and `reset()` to properly clear callbacks and unsubscribe listeners. [[1]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R498-R503) [[2]](diffhunk://#diff-9b7d378baf4b17d45dc612e152f504c35387e658c1bad4cf46cee8805af1ba10R516-R527)

**Development environment:**

* Updated `.vscode/settings.json` to exclude common directories from file watching, improving performance.