### PR TITLE
chore: migrate to @ccp-nc/crystcif-parse v0.3.0 (ESM/TS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@ccp-nc/crystcif-parse": "file:../../crystcif-parse",
+        "@ccp-nc/crystcif-parse": "^0.3.0",
         "@jkshenton/three-bmfont-text": "^4.0.1",
         "buffer": "^6.0.3",
         "chroma-js": "^3.2.0",
@@ -40,34 +40,6 @@
         "msdf-bmfont-xml": "^2.8.0",
         "npm-watch": "^0.13.0",
         "serve": "^14.2.6"
-      }
-    },
-    "../../crystcif-parse": {
-      "name": "@ccp-nc/crystcif-parse",
-      "version": "0.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "mathjs": "^15.1.1",
-        "mendeleev": "^1.2.2"
-      },
-      "bin": {
-        "cifstats": "dist/cifstats.js",
-        "validate-cif": "dist/validate.js"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.0.0",
-        "@types/node": "^25.4.0",
-        "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "@typescript-eslint/parser": "^8.0.0",
-        "eslint": "^9.0.0",
-        "eslint-config-prettier": "^9.0.0",
-        "prettier": "^3.8.1",
-        "tsup": "^8.5.1",
-        "typescript": "^5.9.3",
-        "vitest": "^4.0.18"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -406,8 +378,44 @@
       }
     },
     "node_modules/@ccp-nc/crystcif-parse": {
-      "resolved": "../../crystcif-parse",
-      "link": true
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@ccp-nc/crystcif-parse/-/crystcif-parse-0.3.0.tgz",
+      "integrity": "sha512-h+Few4//q8CbvNXVLMbfSv6o6zdoHJM0ipd8A4alpeI8//RLnm05Qv6qypznhKei0g7Bp3hlsmXazN4h1IOkFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mathjs": "^15.1.1",
+        "mendeleev": "^1.2.2"
+      },
+      "bin": {
+        "cifstats": "dist/cifstats.js",
+        "validate-cif": "dist/validate.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@ccp-nc/crystcif-parse/node_modules/mathjs": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.1.1.tgz",
+      "integrity": "sha512-rM668DTtpSzMVoh/cKAllyQVEbBApM5g//IMGD8vD7YlrIz9ITRr3SrdhjaDxcBNTdyETWwPebj2unZyHD7ZdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -2435,9 +2443,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001778",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+      "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
       "dev": true,
       "funding": [
         {
@@ -3098,9 +3106,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.313",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -3704,9 +3712,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@ccp-nc/crystvis-js",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ccp-nc/crystvis-js",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@ccp-nc/crystcif-parse": "^0.2.9",
+        "@ccp-nc/crystcif-parse": "file:../../crystcif-parse",
         "@jkshenton/three-bmfont-text": "^4.0.1",
         "buffer": "^6.0.3",
         "chroma-js": "^3.2.0",
@@ -18,6 +18,7 @@
         "load-bmfont": "^1.4.2",
         "lodash": "^4.17.23",
         "mathjs": "^14.9.1",
+        "mendeleev": "^1.2.2",
         "three": "^0.178.0",
         "yargs-parser": "^22.0.0"
       },
@@ -39,6 +40,34 @@
         "msdf-bmfont-xml": "^2.8.0",
         "npm-watch": "^0.13.0",
         "serve": "^14.2.6"
+      }
+    },
+    "../../crystcif-parse": {
+      "name": "@ccp-nc/crystcif-parse",
+      "version": "0.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "mathjs": "^15.1.1",
+        "mendeleev": "^1.2.2"
+      },
+      "bin": {
+        "cifstats": "dist/cifstats.js",
+        "validate-cif": "dist/validate.js"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "@types/node": "^25.4.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "prettier": "^3.8.1",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -377,60 +406,8 @@
       }
     },
     "node_modules/@ccp-nc/crystcif-parse": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@ccp-nc/crystcif-parse/-/crystcif-parse-0.2.9.tgz",
-      "integrity": "sha512-T1M6QXSIH12ja59s6n2JR2IFQRaQ6f7sfPqT7TlWh1o8MVe64GqojF1G2SHuqEkyg2dtSAKbSA1MRRyIVafIDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mathjs": "^7.6.0",
-        "mendeleev": "^1.2.2"
-      },
-      "bin": {
-        "validate-cif": "bin/validate.js"
-      }
-    },
-    "node_modules/@ccp-nc/crystcif-parse/node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/@ccp-nc/crystcif-parse/node_modules/mathjs": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-7.6.0.tgz",
-      "integrity": "sha512-abywR28hUpKF4at5jE8Ys+Kigk40eKMT5mcBLD0/dtsqjfOLbtzd3WjlRqIopNo7oQ6FME51qph6lb8h/bhpUg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "complex.js": "^2.0.11",
-        "decimal.js": "^10.2.1",
-        "escape-latex": "^1.2.0",
-        "fraction.js": "^4.0.12",
-        "javascript-natural-sort": "^0.7.1",
-        "seed-random": "^2.2.0",
-        "tiny-emitter": "^2.1.0",
-        "typed-function": "^2.0.0"
-      },
-      "bin": {
-        "mathjs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@ccp-nc/crystcif-parse/node_modules/typed-function": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
-      "integrity": "sha512-bctQIOqx2iVbWGDGPWwIm18QScpu2XRmkC19D8rQGFsjKSgteq/o1hTZvIG/wuDq8fanpBDrLkLq+aEN/6y5XQ==",
-      "engines": {
-        "node": ">= 10"
-      }
+      "resolved": "../../crystcif-parse",
+      "link": true
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -6663,12 +6640,6 @@
       "engines": {
         "node": ">=v12.22.7"
       }
-    },
-    "node_modules/seed-random": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
-      "integrity": "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==",
-      "license": "MIT"
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "homepage": "https://github.com/ccp-nc/crystvis-js#readme",
   "dependencies": {
-    "@ccp-nc/crystcif-parse": "^0.2.9",
+    "@ccp-nc/crystcif-parse": "^0.3.0",
     "@jkshenton/three-bmfont-text": "^4.0.1",
     "buffer": "^6.0.3",
     "chroma-js": "^3.2.0",
@@ -78,6 +78,7 @@
     "load-bmfont": "^1.4.2",
     "lodash": "^4.17.23",
     "mathjs": "^14.9.1",
+    "mendeleev": "^1.2.2",
     "three": "^0.178.0",
     "yargs-parser": "^22.0.0"
   },


### PR DESCRIPTION
- Bump crystcif-parse dependency to ^0.3.0
- Add mendeleev as direct dependency (was previously a phantom transitive dep via crystcif-parse ^0.2.9; v0.3 no longer hoists it)